### PR TITLE
Fix runtime error due to missing file.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 
-import DevApp from './DevApp'
 import App from './App'
 
 // import all CSS


### PR DESCRIPTION
I believe this fixes a runtime error from `npm start` for latest master.