### PR TITLE
QA React challenges 1-6

### DIFF
--- a/src/challenges/react/curriculum/React_01.js
+++ b/src/challenges/react/curriculum/React_01.js
@@ -12,23 +12,17 @@ export const QA = false;
 // -------------- define challenge title and challenge instructions --------------
 export const challengeTitle = `<span class = 'default'>Challenge: </span>Create a Simple JSX Element`
 export const challengeText = `<span class = 'default'>Intro: </span>
-React is an Open Source view library created and maintained by Facebook. It's a great tool for rendering out the UI of 
-modern web applications.<br><br>
+React is an Open Source view library created and maintained by Facebook. It's a great tool to render the User Interface (UI) of modern web applications.<br><br>
 
-React uses a syntax extension of JavaScript called JSX that allows you to write HTML directly within JavaScript. This is very useful because
-it allows you to leverage the full programmatic power of JavaScript within HTML. For the most part, JSX is similar to the HTML that you have
-already learned, however there are a few key differences which we will learn about as we progress through these challenges.<br><br>
+React uses a syntax extension of JavaScript called JSX that allows you to write HTML directly within JavaScript. This has several benefits. It lets you use the full programmatic power of JavaScript within HTML, and helps to keep your code readable. For the most part, JSX is similar to the HTML that you have already learned, however there are a few key differences that will be covered throughout these challenges.<br><br>
 
-For instance, because JSX is a syntatic extension of JavaScript we can actually write JavaScript directly within JSX. To do this we simply
-include whatever we want to be treated as JavaScript within curly braces, <code>{ 'this is treated as JavaScript code' }</code>. We will encounter
-this in several places as we move along, so keep it in mind.<br><br>
+For instance, because JSX is a syntactic extension of JavaScript, you can actually write JavaScript directly within JSX. To do this, you simply include the code you want to be treated as JavaScript within curly braces: <code>{ 'this is treated as JavaScript code' }</code>. Keep this in mind, since it's used in several future challenges.<br><br>
 
-However, because JSX is not valid JavaScript, JSX code must be compiled down to JavaScript. The transpiler Babel
-is the tool of choice for this process, but for your convenience it's all happening behind the scenes here. However, if you happen to write syntactically invalid JSX,
+However, because JSX is not valid JavaScript, JSX code must be compiled into JavaScript. The transpiler Babel is a popular tool for this process. For your convenience, it's already added behind the scenes for these challenges. If you happen to write syntactically invalid JSX,
 you will see the first test in these challenges fail.`
 
 export const challengeInstructions = `<span class = 'default'>Instructions: </span>
-The current code uses JSX to assign a <code>&lt;div&gt;</code> element to the constant <code>JSX</code>. Replace the <code>&lt;div&gt;</code> with an <code>&lt;h1&gt;</code> element
+The current code uses JSX to assign a <code>div</code> element to the constant <code>JSX</code>. Replace the <code>div</code> with an <code>h1</code> element
 and add the text <code>Hello JSX!</code> inside it.`
 
 // ---------------------------- define challenge seed code ----------------------------
@@ -47,24 +41,24 @@ export const executeTests = (code) => {
 		{
 			test: 0,
 			status: false,
-			condition: 'Your JSX code was transpiled successfully.'
+			condition: 'Your JSX code should transpile successfully.'
 		},
 		{
 			test: 1,
 			status: false,
-			condition: 'The constant JSX returns an <h1> element'
+			condition: 'The constant JSX should return an h1 element.'
 		},
 		{
 			test: 2,
 			status: false,
-			condition: 'The <h1> tag includes the text \'Hello JSX!\''
+			condition: 'The h1 tag should include the text \'Hello JSX!\''
 		}
 	];
 
 	const prepend = `(function() {`
 	const apend = `; return JSX })()`
 	const modifiedCode = prepend.concat(code).concat(apend);
-	
+
 	// test 0: try to transpile JSX, ES6 code to ES5 in browser
 	try {
 		es5 = transform(modifiedCode, { presets: [ 'es2015', 'react' ] }).code;
@@ -73,7 +67,7 @@ export const executeTests = (code) => {
 		passed = false;
 		testResults[0].status = false;
 	}
-	
+
 	// shallow render the component with Enzyme
 	try {
 		jsx = eval(es5);
@@ -83,7 +77,7 @@ export const executeTests = (code) => {
 
 	// test 1:
 	try {
-		assert.strictEqual(jsx.type, 'h1', 'The constant JSX returns an <h1> element.');
+		assert.strictEqual(jsx.type, 'h1', 'The constant JSX should return an h1 element.');
 		testResults[1].status = true;
 	} catch (err) {
 		passed = false;
@@ -92,7 +86,7 @@ export const executeTests = (code) => {
 
 	// test 2:
 	try {
-		assert.strictEqual(jsx.props.children, 'Hello JSX!', true, 'The <h1> tag includes the text \'Hello JSX!\'');
+		assert.strictEqual(jsx.props.children, 'Hello JSX!', true, 'The h1 tag should include the text \'Hello JSX!\'');
 		testResults[2].status = true;
 	} catch (err) {
 		passed = false;
@@ -103,7 +97,7 @@ export const executeTests = (code) => {
 		passed,
 		testResults,
 	}
-	
+
 }
 
 // ---------------------------- define live render function ----------------------------

--- a/src/challenges/react/curriculum/React_02.js
+++ b/src/challenges/react/curriculum/React_02.js
@@ -12,22 +12,25 @@ export const QA = false;
 // -------------- define challenge title and challenge instructions --------------
 export const challengeTitle = `<span class = 'default'>Challenge: </span>Create a Complex JSX Element`
 export const challengeText = `<span class = 'default'>Intro: </span>
-That was pretty simple. But JSX can include complex nested HTML as well. Now let's try to use JSX in this way.`
+The last challenge was a simple example of JSX, but it can include complex nested HTML as well.
+
+One important thing to know about nested JSX is that it ultimately needs to return only one outer element. This single parent element would wrap all of the other levels of nested elements. The JSX will not transpile if, for example, your code has several elements that are siblings, but no parent element wrapping all of them. Here's an example:
+<code><blockquote>const JSXValid = (<br>&lt;section&gt;<br>&nbsp;&nbsp;&lt;article&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;p&gt;First article&lt;/p&gt;<br>&nbsp;&nbsp;&lt;/article&gt;<br>&nbsp;&nbsp;&lt;article&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;p&gt;Second article&lt;/p&gt;<br>&nbsp;&nbsp;&lt;/article&gt;<br>&lt;/section&gt;);<br><br>const JSXNotValid = (<br>&lt;article&gt;<br>&nbsp;&nbsp;&lt;p&gt;First article&lt;/p&gt;<br>&lt;/article&gt;<br>&lt;article&gt;<br>&nbsp;&nbsp;&lt;p&gt;Second article&lt;/p&gt;<br>&lt;/article&gt;);</blockquote></code>`
+
+// ^^Multi-line code example follows current FCC formatting once the code tags (wrapping the blockquote) are removed
 
 export const challengeInstructions = `<span class = 'default'>Instructions: </span>
-Define a new constant <code>JSX</code> that renders a <code>&lt;div&gt;</code> which contains the following elements in order:
-a <code>&lt;h1&gt;</code>, a <code>&lt;p&gt;</code>, and an unordered list containing three <code>&lt;li&gt;</code> items. When rendering multiple elements like this, you can wrap them all in parathenses, but it's not strictly required. You should also note that all child elements must be wrapped within a single element. For instance, if you remove the
-<code>&lt;div&gt;</code> that is wrapping all of the elements here, the JSX will no longer transpile. Keep this in mind for later, 
-because it will also apply when we are returning JSX elements in React components. Feel free to include whatever text you want within
-each element.`
+Define a new constant <code>JSX</code> that renders a <code>div</code> which contains the following elements in order:
+An <code>h1</code>, a <code>p</code>, and an unordered list that contains three <code>li</code> items. You can include any text you want within each element.<br><br>
 
-// Maybe here ^^ would be a good place to mention that all nested JSX needs to have only one outer level?
+<strong>Note</strong><br>When rendering multiple elements like this, you can wrap them all in parentheses, but it's not strictly required. Also notice this challenge uses a <code>div</code> tag to wrap all the child elements within a single parent element. If you remove the <code>div</code>, the JSX will no longer transpile. Keep this in mind, since it will also apply when you return JSX elements in React components.`
+
 
 // ---------------------------- define challenge seed code ----------------------------
 export const seedCode = `// write your code here`
 
 // ---------------------------- define challenge solution code ----------------------------
-export const solutionCode = 
+export const solutionCode =
 `const JSX = (
 <div>
 	<h1>Hello JSX!</h1>
@@ -49,39 +52,39 @@ export const executeTests = (code) => {
 		{
 			test: 0,
 			status: false,
-			condition: 'Your JSX code was transpiled successfully.'
+			condition: 'Your JSX code should transpile successfully.'
 		},
 		{
 			test: 1,
 			status: false,
-			condition: 'The constant JSX returns an <div> element.'
+			condition: 'The constant JSX should return a div element.'
 		},
 		{
 			test: 2,
 			status: false,
-			condition: 'The div contains an h1 tag as the second element.'
+			condition: 'The div should contain an h1 tag as the first element.'
 		},
 		{
 			test: 3,
 			status: false,
-			condition: 'The div contains an p tag as the second element.'
+			condition: 'The div should contain a p tag as the second element.'
 		},
 		{
 			test: 4,
 			status: false,
-			condition: 'The div contains a ul tag as the third element.'
+			condition: 'The div should contain a ul tag as the third element.'
 		},
 		{
 			test: 5,
 			status: false,
-			condition: 'The ul contains three li elements.'
+			condition: 'The ul should contain three li elements.'
 		}
 	];
 
 	const prepend = `(function() {`
 	const apend = `; return JSX })()`
 	const modifiedCode = prepend.concat(code).concat(apend);
-	
+
 	// test 0: try to transpile JSX, ES6 code to ES5 in browser
 	try {
 		es5 = transform(modifiedCode, { presets: [ 'es2015', 'react' ] }).code;
@@ -90,7 +93,7 @@ export const executeTests = (code) => {
 		passed = false;
 		testResults[0].status = false;
 	}
-	
+
 	// shallow render the component with Enzyme
 	try {
 		jsx = eval(es5);
@@ -100,7 +103,7 @@ export const executeTests = (code) => {
 
 	// test 1:
 	try {
-		assert.strictEqual(jsx.type, 'div', 'The constant JSX returns an <div> element.');
+		assert.strictEqual(jsx.type, 'div', 'The constant JSX should return a div element.');
 		testResults[1].status = true;
 	} catch (err) {
 		passed = false;
@@ -109,7 +112,7 @@ export const executeTests = (code) => {
 
 	// test 2:
 	try {
-		assert.strictEqual(jsx.props.children[0].type, 'h1', 'The div contains an h1 tag as the first element.');
+		assert.strictEqual(jsx.props.children[0].type, 'h1', 'The div should contain an h1 tag as the first element.');
 		testResults[2].status = true;
 	} catch (err) {
 		passed = false;
@@ -118,7 +121,7 @@ export const executeTests = (code) => {
 
 	// test 3:
 	try {
-		assert.strictEqual(jsx.props.children[1].type, 'p', 'The div contains an p tag as the second element.');
+		assert.strictEqual(jsx.props.children[1].type, 'p', 'The div should contain a p tag as the second element.');
 		testResults[3].status = true;
 	} catch (err) {
 		passed = false;
@@ -127,7 +130,7 @@ export const executeTests = (code) => {
 
 	// test 4:
 	try {
-		assert.strictEqual(jsx.props.children[2].type, 'ul', 'The div contains an h1 tag as the third element.');
+		assert.strictEqual(jsx.props.children[2].type, 'ul', 'The div should contain a ul tag as the third element.');
 		testResults[4].status = true;
 	} catch (err) {
 		passed = false;
@@ -136,18 +139,18 @@ export const executeTests = (code) => {
 
 	// test 5:
 	try {
-		assert.strictEqual(jsx.props.children[2].props.children.length, 3, 'The ul contains three li elements.');
+		assert.strictEqual(jsx.props.children[2].props.children.length, 3, 'The ul should contain three li elements.');
 		testResults[5].status = true;
 	} catch (err) {
 		passed = false;
 		testResults[5].status = false;
-	}	
+	}
 
 	return {
 		passed,
 		testResults,
 	}
-	
+
 }
 
 // ---------------------------- define live render function ----------------------------

--- a/src/challenges/react/curriculum/React_03.js
+++ b/src/challenges/react/curriculum/React_03.js
@@ -12,17 +12,16 @@ export const QA = false;
 // -------------- define challenge title and challenge instructions --------------
 export const challengeTitle = `<span class = 'default'>Challenge: </span>Add Comments in JSX`
 export const challengeText = `<span class = 'default'>Intro: </span>
-JSX is a syntax that gets compiled to JavaScript. But it is a syntax nonetheless.
-Sometimes, for readability, we might need to add comments to our code.<br><br>
+JSX is a syntax that gets compiled into valid JavaScript. Sometimes, for readability, you might need to add comments to your code. Like most programming languages, JSX has its own way to do this.<br><br>
 
-We can put comments inside JSX using the syntax <code>{/* */}</code> to wrap around the comment text.`
+To put comments inside JSX, you use the syntax <code>{/* */}</code> to wrap around the comment text.`
 
 export const challengeInstructions = `<span class = 'default'>Instructions: </span>
-We've provided a JSX element similar to what you just wrote. Add a comment somewhere within the provided <code>&#60;div/&#62</code> element, without
-modifying the existing <code>&lt;h1&gt;</code> or <code>&lt;p&gt;</code> elements.`
+The code editor has a JSX element similar to what you created in the last challenge. Add a comment somewhere within the provided <code>div</code> element, without
+modifying the existing <code>h1</code> or <code>p</code> elements.`
 
 // ---------------------------- define challenge seed code ----------------------------
-export const seedCode = 
+export const seedCode =
 `const JSX = (
 <div>
 	<h1>This is a block of JSX</h1>
@@ -48,27 +47,27 @@ export const executeTests = (code) => {
 		{
 			test: 0,
 			status: false,
-			condition: 'Your JSX code was transpiled successfully.'
+			condition: 'Your JSX code should transpile successfully.'
 		},
 		{
 			test: 1,
 			status: false,
-			condition: 'The constant JSX returns an <div> element.'
+			condition: 'The constant JSX should return a div element.'
 		},
 		{
 			test: 2,
 			status: false,
-			condition: 'The div contains an h1 tag as the first element.'
+			condition: 'The div should contain an h1 tag as the first element.'
 		},
 		{
 			test: 3,
 			status: false,
-			condition: 'The div contains an p tag as the second element.'
+			condition: 'The div should contain a p tag as the second element.'
 		},
 		{
 			test: 4,
 			status: false,
-			condition: 'The JSX includes a comment.'
+			condition: 'The JSX should include a comment.'
 		}
 	];
 
@@ -84,7 +83,7 @@ export const executeTests = (code) => {
 		passed = false;
 		testResults[0].status = false;
 	}
-	
+
 	// shallow render the component with Enzyme
 	try {
 		jsx = eval(es5);
@@ -94,7 +93,7 @@ export const executeTests = (code) => {
 
 	// test 1:
 	try {
-		assert.strictEqual(jsx.type, 'div', 'The constant JSX returns an <div> element.');
+		assert.strictEqual(jsx.type, 'div', 'The constant JSX should return a div element.');
 		testResults[1].status = true;
 	} catch (err) {
 		passed = false;
@@ -103,7 +102,7 @@ export const executeTests = (code) => {
 
 	// test 2:
 	try {
-		assert.strictEqual(jsx.props.children[0].type, 'h1', 'The div contains an h1 tag as the first element.');
+		assert.strictEqual(jsx.props.children[0].type, 'h1', 'The div should contain an h1 tag as the first element.');
 		testResults[2].status = true;
 	} catch (err) {
 		passed = false;
@@ -112,7 +111,7 @@ export const executeTests = (code) => {
 
 	// test 3:
 	try {
-		assert.strictEqual(jsx.props.children[1].type, 'p', 'The div contains an p tag as the second element.');
+		assert.strictEqual(jsx.props.children[1].type, 'p', 'The div should contain a p tag as the second element.');
 		testResults[3].status = true;
 	} catch (err) {
 		passed = false;
@@ -121,18 +120,18 @@ export const executeTests = (code) => {
 
 	// test 4:
 	try {
-		assert.strictEqual(modifiedCode.includes('/*'), true, 'The JSX includes a comment.');
+		assert.strictEqual(modifiedCode.includes('/*'), true, 'The JSX should include a comment.');
 		testResults[4].status = true;
 	} catch (err) {
 		passed = false;
 		testResults[4].status = false;
-	}	
+	}
 
 	return {
 		passed,
 		testResults,
 	}
-	
+
 }
 
 // ---------------------------- define live render function ----------------------------

--- a/src/challenges/react/curriculum/React_04.js
+++ b/src/challenges/react/curriculum/React_04.js
@@ -10,25 +10,20 @@ import { transform } from 'babel-standalone'
 export const QA = false;
 
 // -------------- define challenge title and challenge instructions --------------
-export const challengeTitle = `<span class = 'default'>Challenge: </span>Render HTML Elements to the DOM` 
+export const challengeTitle = `<span class = 'default'>Challenge: </span>Render HTML Elements to the DOM`
 export const challengeText = `<span class = 'default'>Intro: </span>
-Now that we've learned how to compose HTML with JSX, let's learn how React allows us to render this JSX as HTML to the DOM.
-For this we will use React's rendering API known as ReactDOM.<br><br>
+So far, you've learned that JSX is a convenient tool to write readable HTML in a JavaScript file. React allows you to render your JSX as HTML to the DOM. To do this, you use React's rendering API known as ReactDOM.<br><br>
 
-ReactDOM is not complex, it allows us a very simple syntax for rendering React elements 
-to the DOM which looks like this: <code>ReactDOM.render(componentToRender, targetNode)</code>. The
-first argument is the React element or component that we want to render. The second argument is the DOM 
-node that we would like to render the component within. As logic would follow, ReactDOM.render() must be called 
-below where the element has been declared.`
+ReactDOM offers a simple method to render React elements to the DOM which looks like this: <code>ReactDOM.render(componentToRender, targetNode)</code>. The
+first argument is the React element or component that you want to render. The second argument is the DOM node that you want to render the component within. As you would expect, <code>ReactDOM.render()</code> must be called
+after the part in your code where you declared the element you want to render.`
 
 export const challengeInstructions = `<span class = 'default'>Instructions: </span>
-We've defined a simple JSX component for you. Use the <code>ReactDOM.render()</code> method to render this component to the page. 
-You can pass defined JSX elements directly in as the first argument and select the target DOM node with the <code>getElementById()</code>
-method on the document object. We've provided a <code>div</code> with <code>id='challenge-node'</code> for you to use.
-Be sure not to modify the JSX constant at all.`
+The code editor has a simple JSX component. Use the <code>ReactDOM.render()</code> method to render this component to the page. You can pass defined JSX elements directly in as the first argument and select the target DOM node with the <code>getElementById()</code>
+method on the document object. There is a <code>div</code> with <code>id='challenge-node'</code> available for you to use. Make sure you don't change the <code>JSX</code> constant.`
 
 // ---------------------------- define challenge seed code ----------------------------
-export const seedCode = 
+export const seedCode =
 `const JSX = (
 <div>
 	<h1>Hello World</h1>
@@ -61,34 +56,34 @@ export const executeTests = (code) => {
 		{
 			test: 0,
 			status: false,
-			condition: 'Your JSX code was transpiled successfully.'
+			condition: 'Your JSX code should transpile successfully.'
 		},
 		{
 			test: 1,
 			status: false,
-			condition: 'The constant JSX returns an <div> element.'
+			condition: 'The constant JSX should return a div element.'
 		},
 		{
 			test: 2,
 			status: false,
-			condition: 'The div contains an h1 tag as the first element.'
+			condition: 'The div should contain an h1 tag as the first element.'
 		},
 		{
 			test: 3,
 			status: false,
-			condition: 'The div contains an p tag as the second element.'
+			condition: 'The div should contain a p tag as the second element.'
 		},
 		{
 			test: 4,
 			status: false,
-			condition: 'The provided JSX element is rendered to the DOM node with id \'challenge-node\'.'
+			condition: 'The provided JSX element should render to the DOM node with id \'challenge-node\'.'
 		}
 	];
 
 	const prepend = `(function() {`
 	const apend = `; return JSX })()`
 	const modifiedCode = prepend.concat(code).concat(apend);
-	
+
 	// test 0: try to transpile JSX, ES6 code to ES5 in browser
 	try {
 		es5 = transform(modifiedCode, { presets: [ 'es2015', 'react' ] }).code;
@@ -97,7 +92,7 @@ export const executeTests = (code) => {
 		passed = false;
 		testResults[0].status = false;
 	}
-	
+
 	// shallow render the component with Enzyme
 	try {
 		jsx = eval(es5);
@@ -107,7 +102,7 @@ export const executeTests = (code) => {
 
 	// test 1:
 	try {
-		assert.strictEqual(jsx.type, 'div', 'The constant JSX returns an <div> element.');
+		assert.strictEqual(jsx.type, 'div', 'The constant JSX should return a div element.');
 		testResults[1].status = true;
 	} catch (err) {
 		passed = false;
@@ -116,7 +111,7 @@ export const executeTests = (code) => {
 
 	// test 2:
 	try {
-		assert.strictEqual(jsx.props.children[0].type, 'h1', 'The div contains an h1 tag as the first element.');
+		assert.strictEqual(jsx.props.children[0].type, 'h1', 'The div should contain an h1 tag as the first element.');
 		testResults[2].status = true;
 	} catch (err) {
 		passed = false;
@@ -125,7 +120,7 @@ export const executeTests = (code) => {
 
 	// test 3:
 	try {
-		assert.strictEqual(jsx.props.children[1].type, 'p', 'The div contains a p tag as the second element.');
+		assert.strictEqual(jsx.props.children[1].type, 'p', 'The div should contain a p tag as the second element.');
 		testResults[3].status = true;
 	} catch (err) {
 		passed = false;
@@ -134,18 +129,18 @@ export const executeTests = (code) => {
 
 	// test 4:
 	try {
-		assert.strictEqual(document.getElementById('challenge-node').childNodes[0].innerHTML, '<h1>Hello World</h1><p>Lets render this to the DOM</p>', 'The provided JSX element is rendered to the DOM node with id \'challenge-node\'.');
+		assert.strictEqual(document.getElementById('challenge-node').childNodes[0].innerHTML, '<h1>Hello World</h1><p>Lets render this to the DOM</p>', 'The provided JSX element should render to the DOM node with id \'challenge-node\'.');
 		testResults[4].status = true;
 	} catch (err) {
 		passed = false;
 		testResults[4].status = false;
-	}	
+	}
 
 	return {
 		passed,
 		testResults,
 	}
-	
+
 }
 
 // ---------------------------- define live render function ----------------------------

--- a/src/challenges/react/curriculum/React_05.js
+++ b/src/challenges/react/curriculum/React_05.js
@@ -13,17 +13,14 @@ export const QA = false;
 export const challengeTitle = `<span class = 'default'>Challenge: </span>Define an HTML Class in JSX`
 export const challengeText = `<span class = 'default'>Intro: </span>
 Now that you're getting comfortable writing JSX you may be wondering how it differs from HTML.
-So far it seems as though you can use HTML and JSX interchangeably, right?<br><br>
+So far it may seem that HTML and JSX are exactly the same.<br><br>
 
-One key difference in JSX is that you can no longer use the word <code>class</code> to define HTML classes, because <code>class</code> is a
-reserved word in JavaScript. In its place we will use <code>className</code> in JSX.<br><br>
+One key difference in JSX is that you can no longer use the word <code>class</code> to define HTML classes. This is because <code>class</code> is a reserved word in JavaScript. Instead, JSX uses <code>className</code>.<br><br>
 
-In fact, we will see in later challenges, that the naming convention for all HTML attributes and event references in JSX become camelCase. For example,
-we would refer to a click event as <code>onClick</code> in JSX, rather than <code>onclick</code>. Likewise, <code>onchange</code> becomes <code>onChange</code>, and so on. While this is a subtle 
-difference, it is an important one that we must bear in mind as we move forward.`
+In fact, the naming convention for all HTML attributes and event references in JSX become camelCase. For example, a click event in JSX is <code>onClick</code>, instead of <code>onclick</code>. Likewise, <code>onchange</code> becomes <code>onChange</code>. While this is a subtle difference, it is an important one to keep in mind moving forward.`
 
 export const challengeInstructions = `<span class = 'default'>Instructions: </span>
-Apply a class of <code>myDiv</code> to the <code>&lt;div&gt;</code> provided in the JSX code.`
+Apply a class of <code>myDiv</code> to the <code>div</code> provided in the JSX code.`
 
 // ---------------------------- define challenge seed code ----------------------------
 export const seedCode =
@@ -33,7 +30,7 @@ export const seedCode =
 </div>);`
 
 // ---------------------------- define challenge solution code ----------------------------
-export const solutionCode = 
+export const solutionCode =
 `const JSX = (
 <div className = 'myDiv'>
 	<h1>Add a class to this div</h1>
@@ -49,12 +46,12 @@ export const executeTests = (code) => {
 		{
 			test: 0,
 			status: false,
-			condition: 'Your JSX code was transpiled successfully.'
+			condition: 'Your JSX code should transpile successfully.'
 		},
 		{
 			test: 1,
 			status: false,
-			condition: 'The constant JSX returns a <div> element.'
+			condition: 'The constant JSX should return a div element.'
 		},
 		{
 			test: 2,
@@ -75,7 +72,7 @@ export const executeTests = (code) => {
 		passed = false;
 		testResults[0].status = false;
 	}
-	
+
 	// shallow render the component with Enzyme
 	try {
 		jsx = eval(es5);
@@ -85,7 +82,7 @@ export const executeTests = (code) => {
 
 	// test 1:
 	try {
-		assert.strictEqual(jsx.type, 'div', 'The constant JSX returns an <div> element.');
+		assert.strictEqual(jsx.type, 'div', 'The constant JSX should return a div element.');
 		testResults[1].status = true;
 	} catch (err) {
 		passed = false;
@@ -105,7 +102,7 @@ export const executeTests = (code) => {
 		passed,
 		testResults,
 	}
-	
+
 }
 
 // ---------------------------- define live render function ----------------------------

--- a/src/challenges/react/curriculum/React_06.js
+++ b/src/challenges/react/curriculum/React_06.js
@@ -12,27 +12,21 @@ export const challengeTitle = `<span class = 'default'>Challenge: </span>Learn A
 
 // ---------------------------- challenge text ----------------------------
 export const challengeText = `<span class = 'default'>Intro: </span>
-So far, we’ve seen how JSX differs from HTML in a key way with the use of <code>className</code> vs. <code>class</code> for defining HTML classes. 
-Another important way in which JSX differs from HTML is in the idea of the self closing tag.<br><br>
+So far, you’ve seen how JSX differs from HTML in a key way with the use of <code>className</code> vs. <code>class</code> for defining HTML classes.
+Another important way in which JSX differs from HTML is in the idea of the self-closing tag.<br><br>
 
-In HTML, almost all tags have both an opening and closing tag: <code>&lt;div&gt;&lt;/div&gt;</code>; the closing tag always has a forward slash before the tag name that we are closing. 
-However, there are special instances in HTML where we have “self closing tags”, or tags that don’t require both an opening and closing tag before another tag can start. 
-For example the line-break tag can be written as <code>&lt;br&gt;</code> or as <code>&lt;br /&gt;</code>, but should never be written as <code>&lt;br&gt;&lt;/br&gt;</code>, as it does not contain any content.<br><br> 
+In HTML, almost all tags have both an opening and closing tag: <code>&lt;div&gt;&lt;/div&gt;</code>; the closing tag always has a forward slash before the tag name that you are closing. However, there are special instances in HTML called “self-closing tags”, or tags that don’t require both an opening and closing tag before another tag can start.
+For example the line-break tag can be written as <code>&lt;br&gt;</code> or as <code>&lt;br /&gt;</code>, but should never be written as <code>&lt;br&gt;&lt;/br&gt;</code>, since it doesn't contain any content.<br><br>
 
-In JSX though, the rules are a little different. Any JSX element can be written with a self-closing tag, and every element must be closed.
-So the line-break tag, for example, must always be written as <code>&lt;br /&gt;</code> in order to be valid JSX than can be transpiled. 
-A <code>&lt;div&gt;</code>, on the other hand, can be written as <code>&lt;div /&gt;</code> or <code>&lt;div&gt;&lt;/div&gt;</code>. With
-that first syntax there is no way to include anything in the <code>&lt;div&gt;</code>, of course.
-We will see later that this syntax also comes in handy when rendering React components.`
+In JSX, the rules are a little different. Any JSX element can be written with a self-closing tag, and every element must be closed. The line-break tag, for example, must always be written as <code>&lt;br /&gt;</code> in order to be valid JSX than can be transpiled. A <code>&lt;div&gt;</code>, on the other hand, can be written as <code>&lt;div /&gt;</code> or <code>&lt;div&gt;&lt;/div&gt;</code>. The difference is that in the first syntax version there is no way to include anything in the <code>&lt;div /&gt;</code>. You will see in later challenges that this syntax is useful when rendering React components.`
 
 // ---------------------------- challenge instructions ----------------------------
 export const challengeInstructions = `<span class = 'default'>Instructions: </span>
-Fix the errors in the code below so that it is valid JSX that can be successfully transpiled and render it to the DOM using the <code>ReactDOM.render()</code> method.
-We've provided a <code>&lt;div&gt;</code> with <code>id='challenge-node'</code> for you to render to. Be sure not to change any of the content but only to add self-closing tags where
+Fix the errors in the code editor so that it is valid JSX and successfully transpiles. Make sure you don't change any of the content - you only need to close tags where
 they are needed.`
 
 // ---------------------------- define challenge seed code ----------------------------
-export const seedCode = 
+export const seedCode =
 `const JSX = (
 <div>
 	{/* change code below this line */}
@@ -45,7 +39,7 @@ export const seedCode =
 ReactDOM.render(JSX, document.getElementById('challenge-node'));`
 
 // ---------------------------- define challenge solution code ----------------------------
-export const solutionCode = 
+export const solutionCode =
 `const JSX = (
 <div>
 	{/* change code below this line */}
@@ -67,34 +61,34 @@ export const executeTests = (code) => {
 		{
 			test: 0,
 			status: false,
-			condition: 'Your JSX code was transpiled successfully.'
+			condition: 'Your JSX code should transpile successfully.'
 		},
 		{
 			test: 1,
 			status: false,
-			condition: 'The constant JSX returns an <div> element.'
+			condition: 'The constant JSX should return a div element.'
 		},
 		{
 			test: 2,
 			status: false,
-			condition: 'The div contains a br tag.'
+			condition: 'The div should contain a br tag.'
 		},
 		{
 			test: 3,
 			status: false,
-			condition: 'The div contains an img tag.'
+			condition: 'The div should contain an img tag.'
 		},
 		{
 			test: 4,
 			status: false,
-			condition: 'The provided JSX element is rendered to the DOM node with id \'challenge-node\'.'
+			condition: 'The provided JSX element should render to the DOM node with id \'challenge-node\'.'
 		}
 	];
 
 	const prepend = `(function() {`
 	const apend = `; return JSX })()`
 	const modifiedCode = prepend.concat(code).concat(apend);
-	
+
 	// test 0: try to transpile JSX, ES6 code to ES5 in browser
 	try {
 		es5 = transform(modifiedCode, { presets: [ 'es2015', 'react' ] }).code;
@@ -103,7 +97,7 @@ export const executeTests = (code) => {
 		passed = false;
 		testResults[0].status = false;
 	}
-	
+
 	// shallow render the component with Enzyme
 	try {
 		jsx = eval(es5);
@@ -113,8 +107,8 @@ export const executeTests = (code) => {
 
 	// test 1:
 	try {
-		
-		assert.strictEqual(jsx.type, 'div', 'The constant JSX returns an <div> element.');
+
+		assert.strictEqual(jsx.type, 'div', 'The constant JSX should return a div element.');
 		testResults[1].status = true;
 	} catch (err) {
 		passed = false;
@@ -123,7 +117,7 @@ export const executeTests = (code) => {
 
 	// test 2:
 	try {
-		assert.strictEqual(jsx.props.children[2].type, 'br', 'The div contains a br tag.');
+		assert.strictEqual(jsx.props.children[2].type, 'br', 'The div should contain a br tag.');
 		testResults[2].status = true;
 	} catch (err) {
 		passed = false;
@@ -132,7 +126,7 @@ export const executeTests = (code) => {
 
 	// test 3:
 	try {
-		assert.strictEqual(jsx.props.children[3].type, 'img', 'The div contains an img tag.');
+		assert.strictEqual(jsx.props.children[3].type, 'img', 'The div should contain an img tag.');
 		testResults[3].status = true;
 	} catch (err) {
 		passed = false;
@@ -145,19 +139,19 @@ export const executeTests = (code) => {
 		assert(
 			testDiv.includes('<p>WelcometoReact!</p>') &&
 			testDiv.includes('<br><imgsrc="https://goo.gl/ErGBQs"alt="ReactLogo">'),
-			'The provided JSX element is rendered as is to the DOM node with id \'challenge-node\'.'
+			'The provided JSX element should render as is to the DOM node with id \'challenge-node\'.'
 		);
 		testResults[4].status = true;
 	} catch (err) {
 		passed = false;
 		testResults[4].status = false;
-	}	
+	}
 
 	return {
 		passed,
 		testResults,
 	}
-	
+
 }
 
 // ---------------------------- define live render function ----------------------------


### PR DESCRIPTION
Conforms the text in the React section's challenges (1-6) to other curriculum expansion sections. All challenge tests still pass in the browser.

One point potentially for discussion:
Challenge 2: Create a Complete JSX Element adds a multi-line code example. It's wrapped in `blockquote` tags, which what the FCC site uses to style these, then wrapped in `code` tags to get the pink text. The current formatting looks a bit rough using the `code` tags. We can remove the example entirely if it's not needed, move it into a comment in the source code (it won't show on this site, but would get seeded when the challenges are ported to FCC), or keep as-is.