### PR TITLE
enforce immutability for redux challenges, editor addons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2,7 +2,6 @@
   "name": "fcc-react-challenge-tests-prototype",
   "version": "0.0.1",
   "lockfileVersion": 1,
-  "requires": true,
   "dependencies": {
     "abab": {
       "version": "https://registry.npmjs.org/abab/-/abab-1.0.3.tgz",
@@ -17,11 +16,7 @@
     "accepts": {
       "version": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
       "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
-      "dev": true,
-      "requires": {
-        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
-        "negotiator": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
-      }
+      "dev": true
     },
     "acorn": {
       "version": "https://registry.npmjs.org/acorn/-/acorn-4.0.3.tgz",
@@ -32,9 +27,6 @@
       "version": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
       "integrity": "sha1-VbtemGkVB7dFedBRNBMhfDgMVM8=",
       "dev": true,
-      "requires": {
-        "acorn": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
-      },
       "dependencies": {
         "acorn": {
           "version": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
@@ -47,9 +39,6 @@
       "version": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
-      "requires": {
-        "acorn": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz"
-      },
       "dependencies": {
         "acorn": {
           "version": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
@@ -61,11 +50,7 @@
     "ajv": {
       "version": "https://registry.npmjs.org/ajv/-/ajv-4.9.0.tgz",
       "integrity": "sha1-WjWAhXR7E061Z9bRXgFfHXgC9Fw=",
-      "dev": true,
-      "requires": {
-        "co": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-        "json-stable-stringify": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
-      }
+      "dev": true
     },
     "ajv-keywords": {
       "version": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.1.1.tgz",
@@ -75,12 +60,7 @@
     "align-text": {
       "version": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true,
-      "requires": {
-        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
-        "longest": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-        "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
-      }
+      "dev": true
     },
     "alphanum-sort": {
       "version": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
@@ -120,11 +100,7 @@
     "anymatch": {
       "version": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
       "integrity": "sha1-o+Uvo5FoyCX/V7AkgSbOWo/5VQc=",
-      "dev": true,
-      "requires": {
-        "arrify": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-        "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz"
-      }
+      "dev": true
     },
     "append-transform": {
       "version": "https://registry.npmjs.org/append-transform/-/append-transform-0.3.0.tgz",
@@ -134,18 +110,12 @@
     "argparse": {
       "version": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-      "dev": true,
-      "requires": {
-        "sprintf-js": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
-      }
+      "dev": true
     },
     "arr-diff": {
       "version": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-      "dev": true,
-      "requires": {
-        "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
-      }
+      "dev": true
     },
     "arr-flatten": {
       "version": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
@@ -170,10 +140,7 @@
     "array-union": {
       "version": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true,
-      "requires": {
-        "array-uniq": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz"
-      }
+      "dev": true
     },
     "array-uniq": {
       "version": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
@@ -202,10 +169,7 @@
     "assert": {
       "version": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
       "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
-      "dev": true,
-      "requires": {
-        "util": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
-      }
+      "dev": true
     },
     "assert-plus": {
       "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
@@ -230,15 +194,7 @@
     "autoprefixer": {
       "version": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.5.1.tgz",
       "integrity": "sha1-rnWaUiHnCfPaF8LWViMOZ8Q8u3U=",
-      "dev": true,
-      "requires": {
-        "browserslist": "https://registry.npmjs.org/browserslist/-/browserslist-1.4.0.tgz",
-        "caniuse-db": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000588.tgz",
-        "normalize-range": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-        "num2fraction": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
-        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.6.tgz",
-        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
-      }
+      "dev": true
     },
     "aws-sign2": {
       "version": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
@@ -254,10 +210,6 @@
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.16.2.tgz",
       "integrity": "sha1-uk+S8XFn37q0CYN4VFS5rBScPG0=",
-      "requires": {
-        "follow-redirects": "1.2.5",
-        "is-buffer": "1.1.5"
-      },
       "dependencies": {
         "is-buffer": {
           "version": "1.1.5",
@@ -269,40 +221,12 @@
     "babel-code-frame": {
       "version": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
       "integrity": "sha1-+Q5g2ghikJ084JhzO105h8l8uN4=",
-      "dev": true,
-      "requires": {
-        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-        "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-        "js-tokens": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
-      }
+      "dev": true
     },
     "babel-core": {
       "version": "https://registry.npmjs.org/babel-core/-/babel-core-6.17.0.tgz",
       "integrity": "sha1-bEV2RH30eeJB5YyAfkvH2k239CU=",
       "dev": true,
-      "requires": {
-        "babel-code-frame": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-        "babel-generator": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.19.0.tgz",
-        "babel-helpers": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.16.0.tgz",
-        "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-        "babel-register": "https://registry.npmjs.org/babel-register/-/babel-register-6.18.0.tgz",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
-        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
-        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.19.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-        "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
-        "convert-source-map": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.3.0.tgz",
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-        "json5": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-        "path-exists": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
-        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-        "private": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
-        "shebang-regex": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-        "slash": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
-      },
       "dependencies": {
         "path-exists": {
           "version": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
@@ -314,210 +238,102 @@
     "babel-eslint": {
       "version": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-7.0.0.tgz",
       "integrity": "sha1-VOUbQDP1SsgTJuzqTGRqd5k1GW0=",
-      "dev": true,
-      "requires": {
-        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.19.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-        "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
-        "lodash.pickby": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz"
-      }
+      "dev": true
     },
     "babel-generator": {
       "version": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.19.0.tgz",
       "integrity": "sha1-my8kQgR3ej1oEOwSfGc8h7NJ+sU=",
-      "dev": true,
-      "requires": {
-        "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-        "detect-indent": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-        "jsesc": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
-      }
+      "dev": true
     },
     "babel-helper-builder-binary-assignment-operator-visitor": {
       "version": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.18.0.tgz",
       "integrity": "sha1-iugUmJ96U2ghUuNAGgT6vQuzM6Y=",
-      "dev": true,
-      "requires": {
-        "babel-helper-explode-assignable-expression": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.18.0.tgz",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz"
-      }
+      "dev": true
     },
     "babel-helper-builder-react-jsx": {
       "version": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.18.0.tgz",
       "integrity": "sha1-qwLxmi63rOk23Yf6VYltAr5Zv3E=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-        "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
-      }
+      "dev": true
     },
     "babel-helper-call-delegate": {
       "version": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.18.0.tgz",
       "integrity": "sha1-BbFKr6QwiEsDQJfvKenwZ+pBM70=",
-      "dev": true,
-      "requires": {
-        "babel-helper-hoist-variables": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.18.0.tgz",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
-        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.19.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz"
-      }
+      "dev": true
     },
     "babel-helper-define-map": {
       "version": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.18.0.tgz",
       "integrity": "sha1-jWyF3H+7TBm+PeQEdNGOl8NnbsI=",
-      "dev": true,
-      "requires": {
-        "babel-helper-function-name": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.18.0.tgz",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
-      }
+      "dev": true
     },
     "babel-helper-explode-assignable-expression": {
       "version": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.18.0.tgz",
       "integrity": "sha1-FLjowtA61zXUsg8YQLJM0fZSOf4=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
-        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.19.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz"
-      }
+      "dev": true
     },
     "babel-helper-function-name": {
       "version": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.18.0.tgz",
       "integrity": "sha1-aOxxrrofPiiypvBzAZC3VKm/MOY=",
-      "dev": true,
-      "requires": {
-        "babel-helper-get-function-arity": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.18.0.tgz",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
-        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
-        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.19.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz"
-      }
+      "dev": true
     },
     "babel-helper-get-function-arity": {
       "version": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.18.0.tgz",
       "integrity": "sha1-pbGWlf0/nN/DKDmLR9r81wlPnyQ=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz"
-      }
+      "dev": true
     },
     "babel-helper-hoist-variables": {
       "version": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.18.0.tgz",
       "integrity": "sha1-qDW1q4tG1t6bq++uTZjqQehmuCo=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz"
-      }
+      "dev": true
     },
     "babel-helper-optimise-call-expression": {
       "version": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.18.0.tgz",
       "integrity": "sha1-kmHQKZ7hpPCKbdKLe3x3c0j9jw8=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz"
-      }
+      "dev": true
     },
     "babel-helper-regex": {
       "version": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.18.0.tgz",
       "integrity": "sha1-rg6/133obLLxryWOLMILX+iT7MY=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
-      }
+      "dev": true
     },
     "babel-helper-remap-async-to-generator": {
       "version": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.18.0.tgz",
       "integrity": "sha1-M2zfPKtlC7GRsC/BajcI575/nOU=",
-      "dev": true,
-      "requires": {
-        "babel-helper-function-name": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.18.0.tgz",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
-        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
-        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.19.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz"
-      }
+      "dev": true
     },
     "babel-helper-replace-supers": {
       "version": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.18.0.tgz",
       "integrity": "sha1-KOxph3vkFE29ZPTMOjN+ifKakk4=",
-      "dev": true,
-      "requires": {
-        "babel-helper-optimise-call-expression": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.18.0.tgz",
-        "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
-        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
-        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.19.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz"
-      }
+      "dev": true
     },
     "babel-helpers": {
       "version": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.16.0.tgz",
       "integrity": "sha1-EJXsENmSeUYFU+Z+s+7plz04Z+M=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
-        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz"
-      }
+      "dev": true
     },
     "babel-jest": {
       "version": "https://registry.npmjs.org/babel-jest/-/babel-jest-16.0.0.tgz",
       "integrity": "sha1-NIcprqbWJKR3S4qTTQekDdLP1kA=",
-      "dev": true,
-      "requires": {
-        "babel-core": "https://registry.npmjs.org/babel-core/-/babel-core-6.17.0.tgz",
-        "babel-plugin-istanbul": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-2.0.3.tgz",
-        "babel-preset-jest": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-16.0.0.tgz"
-      }
+      "dev": true
     },
     "babel-loader": {
       "version": "https://registry.npmjs.org/babel-loader/-/babel-loader-6.2.5.tgz",
       "integrity": "sha1-V21UhSBoml5rcMZbhddq8f/t0AU=",
-      "dev": true,
-      "requires": {
-        "loader-utils": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.16.tgz",
-        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
-      }
+      "dev": true
     },
     "babel-messages": {
       "version": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
       "integrity": "sha1-v1BHNsqWfm1l7wrbWipflHyODrk=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz"
-      }
+      "dev": true
     },
     "babel-plugin-check-es2015-constants": {
       "version": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.8.0.tgz",
       "integrity": "sha1-2/Akwy7Te/2o3uHnbaAjhqjSb+c=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz"
-      }
+      "dev": true
     },
     "babel-plugin-istanbul": {
       "version": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-2.0.3.tgz",
       "integrity": "sha1-JmswS5EJYH1gdIR0OUZ2mC9mDfQ=",
-      "dev": true,
-      "requires": {
-        "find-up": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-        "istanbul-lib-instrument": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.3.0.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-        "test-exclude": "https://registry.npmjs.org/test-exclude/-/test-exclude-2.1.3.tgz"
-      }
+      "dev": true
     },
     "babel-plugin-jest-hoist": {
       "version": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-16.0.0.tgz",
@@ -562,501 +378,234 @@
     "babel-plugin-transform-async-to-generator": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.16.0.tgz",
       "integrity": "sha1-Gew2yxSGtZ+fRorfpCzhOQjKKZk=",
-      "dev": true,
-      "requires": {
-        "babel-helper-remap-async-to-generator": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.18.0.tgz",
-        "babel-plugin-syntax-async-functions": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz"
-      }
+      "dev": true
     },
     "babel-plugin-transform-class-properties": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.16.0.tgz",
       "integrity": "sha1-lpvKJNNOQB0hTza4r1wTRoWbyQQ=",
-      "dev": true,
-      "requires": {
-        "babel-helper-function-name": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.18.0.tgz",
-        "babel-plugin-syntax-class-properties": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-arrow-functions": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.8.0.tgz",
       "integrity": "sha1-W2Ovwxgb3JqMTUgbWk8/fX/vPZ0=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.8.0.tgz",
       "integrity": "sha1-7ZXWKcS1pxriloK5mPcNmDPrNm0=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-block-scoping": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.18.0.tgz",
       "integrity": "sha1-O/3P7DGNRt8iUlzeqI8ZeIE2U68=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
-        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
-        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.19.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-classes": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.18.0.tgz",
       "integrity": "sha1-/+ehcyG/g+SU3NoK4/xy30j/0dk=",
-      "dev": true,
-      "requires": {
-        "babel-helper-define-map": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.18.0.tgz",
-        "babel-helper-function-name": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.18.0.tgz",
-        "babel-helper-optimise-call-expression": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.18.0.tgz",
-        "babel-helper-replace-supers": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.18.0.tgz",
-        "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
-        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
-        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.19.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-computed-properties": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.8.0.tgz",
       "integrity": "sha1-9RAQ/WGzvXtrYKX9/TB7t6UnmHA=",
-      "dev": true,
-      "requires": {
-        "babel-helper-define-map": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.18.0.tgz",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
-        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-destructuring": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.16.0.tgz",
       "integrity": "sha1-BQ/ghm9dU7NgYu4QzfW/5k+Slic=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.8.0.tgz",
       "integrity": "sha1-/Y9/cXH8EIzBxwwxZLnxWoHCX30=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-for-of": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.18.0.tgz",
       "integrity": "sha1-TFF1BNtkv4z8EZprjxdyEfICinA=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-function-name": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.9.0.tgz",
       "integrity": "sha1-jBNbF9vQZOW7pW7FEbqu4vyoJxk=",
-      "dev": true,
-      "requires": {
-        "babel-helper-function-name": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.18.0.tgz",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-literals": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.8.0.tgz",
       "integrity": "sha1-UKouXHlY/CqyXXTsEX4MyY8EZGg=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-modules-amd": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.18.0.tgz",
       "integrity": "sha1-SaBUy7divfmuLYqAcHbPreYUHkA=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.18.0.tgz",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
-        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.18.0.tgz",
       "integrity": "sha1-wVrluxGzKgq9zJilg3uqTujWe8w=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-transform-strict-mode": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.18.0.tgz",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
-        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.19.0.tgz",
       "integrity": "sha1-UEOBNuunRSfvoApbD++vHcQHHaY=",
-      "dev": true,
-      "requires": {
-        "babel-helper-hoist-variables": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.18.0.tgz",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
-        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-modules-umd": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.18.0.tgz",
       "integrity": "sha1-IzUXcOzlwfjoPtZ8sdeZKIRJHlA=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-transform-es2015-modules-amd": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.18.0.tgz",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
-        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-object-super": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.8.0.tgz",
       "integrity": "sha1-G4WHQKWkQAiHwj3P9vTVbupKJMU=",
-      "dev": true,
-      "requires": {
-        "babel-helper-replace-supers": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.18.0.tgz",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-parameters": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.17.0.tgz",
       "integrity": "sha1-4G0wzviX9GrbRzRwe74Sig1CfVg=",
-      "dev": true,
-      "requires": {
-        "babel-helper-call-delegate": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.18.0.tgz",
-        "babel-helper-get-function-arity": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.18.0.tgz",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
-        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
-        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.19.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.18.0.tgz",
       "integrity": "sha1-4u3jt99Hv5gBUZJlNNHdDL6lj0M=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-spread": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.8.0.tgz",
       "integrity": "sha1-Ahf3N+O4IfpaZp8YfG7VkgXwXpw=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-sticky-regex": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.8.0.tgz",
       "integrity": "sha1-5z0wCkQKNdXGT1wqNE3CNuPfR74=",
-      "dev": true,
-      "requires": {
-        "babel-helper-regex": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.18.0.tgz",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-template-literals": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.8.0.tgz",
       "integrity": "sha1-huuHbQosY12k7ASLT33p38iX5ms=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.18.0.tgz",
       "integrity": "sha1-CxTEhinJD/R6BlAHf2qmmb7jV5g=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-unicode-regex": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.11.0.tgz",
       "integrity": "sha1-YpjOq6rYjVCj9POS2N6ZcmD27yw=",
-      "dev": true,
-      "requires": {
-        "babel-helper-regex": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.18.0.tgz",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
-        "regexpu-core": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz"
-      }
+      "dev": true
     },
     "babel-plugin-transform-exponentiation-operator": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.8.0.tgz",
       "integrity": "sha1-2yV0LpM56t5nbKms7Eb5VVmaaKQ=",
-      "dev": true,
-      "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.18.0.tgz",
-        "babel-plugin-syntax-exponentiation-operator": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz"
-      }
+      "dev": true
     },
     "babel-plugin-transform-flow-strip-types": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.18.0.tgz",
       "integrity": "sha1-TT5kIVhmHptA20V8AEowgX+jJZI=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-syntax-flow": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz"
-      }
+      "dev": true
     },
     "babel-plugin-transform-object-rest-spread": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.16.0.tgz",
       "integrity": "sha1-20QdVv/8GZkFL96+Li8l69KONqk=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-syntax-object-rest-spread": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz"
-      }
+      "dev": true
     },
     "babel-plugin-transform-react-constant-elements": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-react-constant-elements/-/babel-plugin-transform-react-constant-elements-6.9.1.tgz",
       "integrity": "sha1-EluG2WyzIuITm2B/10mtX7sX8AU=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz"
-      }
+      "dev": true
     },
     "babel-plugin-transform-react-display-name": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.8.0.tgz",
       "integrity": "sha1-96CEl3OD1yi9vcKDW7oBWVd/Zg4=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz"
-      }
+      "dev": true
     },
     "babel-plugin-transform-react-jsx": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.8.0.tgz",
       "integrity": "sha1-lHWZQvcK8YxhcYmqfzWT8WRKcas=",
-      "dev": true,
-      "requires": {
-        "babel-helper-builder-react-jsx": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.18.0.tgz",
-        "babel-plugin-syntax-jsx": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz"
-      }
+      "dev": true
     },
     "babel-plugin-transform-react-jsx-self": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.11.0.tgz",
       "integrity": "sha1-YFyUUMFCn5epMPfh3+Pw2dDb0PQ=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-syntax-jsx": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz"
-      }
+      "dev": true
     },
     "babel-plugin-transform-react-jsx-source": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.9.0.tgz",
       "integrity": "sha1-r2hKBcIGeobglX1PNDKVzPXczwA=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-syntax-jsx": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz"
-      }
+      "dev": true
     },
     "babel-plugin-transform-regenerator": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.16.1.tgz",
       "integrity": "sha1-p13msEihQVSq4UsBInVsW+05L1k=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-        "private": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
-      }
+      "dev": true
     },
     "babel-plugin-transform-runtime": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.15.0.tgz",
       "integrity": "sha1-PXW02Umtga8VdXAnOEb7Wa6w1Xw=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz"
-      }
+      "dev": true
     },
     "babel-plugin-transform-strict-mode": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.18.0.tgz",
       "integrity": "sha1-33zymR/gRvRBY9zRENXKQ7xlK50=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz"
-      }
+      "dev": true
     },
     "babel-preset-env": {
       "version": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-0.0.6.tgz",
       "integrity": "sha1-zaY6AgBpCY+tEicqekR6fFuvs8g=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-check-es2015-constants": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.8.0.tgz",
-        "babel-plugin-syntax-trailing-function-commas": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.13.0.tgz",
-        "babel-plugin-transform-async-to-generator": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.16.0.tgz",
-        "babel-plugin-transform-es2015-arrow-functions": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.8.0.tgz",
-        "babel-plugin-transform-es2015-block-scoped-functions": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.8.0.tgz",
-        "babel-plugin-transform-es2015-block-scoping": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.18.0.tgz",
-        "babel-plugin-transform-es2015-classes": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.18.0.tgz",
-        "babel-plugin-transform-es2015-computed-properties": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.8.0.tgz",
-        "babel-plugin-transform-es2015-destructuring": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.16.0.tgz",
-        "babel-plugin-transform-es2015-duplicate-keys": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.8.0.tgz",
-        "babel-plugin-transform-es2015-for-of": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.18.0.tgz",
-        "babel-plugin-transform-es2015-function-name": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.9.0.tgz",
-        "babel-plugin-transform-es2015-literals": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.8.0.tgz",
-        "babel-plugin-transform-es2015-modules-amd": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.18.0.tgz",
-        "babel-plugin-transform-es2015-modules-commonjs": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.18.0.tgz",
-        "babel-plugin-transform-es2015-modules-systemjs": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.19.0.tgz",
-        "babel-plugin-transform-es2015-modules-umd": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.18.0.tgz",
-        "babel-plugin-transform-es2015-object-super": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.8.0.tgz",
-        "babel-plugin-transform-es2015-parameters": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.17.0.tgz",
-        "babel-plugin-transform-es2015-shorthand-properties": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.18.0.tgz",
-        "babel-plugin-transform-es2015-spread": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.8.0.tgz",
-        "babel-plugin-transform-es2015-sticky-regex": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.8.0.tgz",
-        "babel-plugin-transform-es2015-template-literals": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.8.0.tgz",
-        "babel-plugin-transform-es2015-typeof-symbol": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.18.0.tgz",
-        "babel-plugin-transform-es2015-unicode-regex": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.11.0.tgz",
-        "babel-plugin-transform-exponentiation-operator": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.8.0.tgz",
-        "babel-plugin-transform-regenerator": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.16.1.tgz",
-        "browserslist": "https://registry.npmjs.org/browserslist/-/browserslist-1.4.0.tgz"
-      }
+      "dev": true
     },
     "babel-preset-es2015": {
       "version": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.18.0.tgz",
       "integrity": "sha1-uMcN+E7JSMQ9zyv3cOmI632ogxI=",
       "dev": true,
-      "requires": {
-        "babel-plugin-check-es2015-constants": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.8.0.tgz",
-        "babel-plugin-transform-es2015-arrow-functions": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.8.0.tgz",
-        "babel-plugin-transform-es2015-block-scoped-functions": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.8.0.tgz",
-        "babel-plugin-transform-es2015-block-scoping": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.18.0.tgz",
-        "babel-plugin-transform-es2015-classes": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.18.0.tgz",
-        "babel-plugin-transform-es2015-computed-properties": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.8.0.tgz",
-        "babel-plugin-transform-es2015-destructuring": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.19.0.tgz",
-        "babel-plugin-transform-es2015-duplicate-keys": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.8.0.tgz",
-        "babel-plugin-transform-es2015-for-of": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.18.0.tgz",
-        "babel-plugin-transform-es2015-function-name": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.9.0.tgz",
-        "babel-plugin-transform-es2015-literals": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.8.0.tgz",
-        "babel-plugin-transform-es2015-modules-amd": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.18.0.tgz",
-        "babel-plugin-transform-es2015-modules-commonjs": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.18.0.tgz",
-        "babel-plugin-transform-es2015-modules-systemjs": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.19.0.tgz",
-        "babel-plugin-transform-es2015-modules-umd": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.18.0.tgz",
-        "babel-plugin-transform-es2015-object-super": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.8.0.tgz",
-        "babel-plugin-transform-es2015-parameters": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.18.0.tgz",
-        "babel-plugin-transform-es2015-shorthand-properties": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.18.0.tgz",
-        "babel-plugin-transform-es2015-spread": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.8.0.tgz",
-        "babel-plugin-transform-es2015-sticky-regex": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.8.0.tgz",
-        "babel-plugin-transform-es2015-template-literals": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.8.0.tgz",
-        "babel-plugin-transform-es2015-typeof-symbol": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.18.0.tgz",
-        "babel-plugin-transform-es2015-unicode-regex": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.11.0.tgz",
-        "babel-plugin-transform-regenerator": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.16.1.tgz"
-      },
       "dependencies": {
         "babel-plugin-transform-es2015-destructuring": {
           "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.19.0.tgz",
           "integrity": "sha1-/x2RHEs/TKtiG9ZnAqhprNGQBTM=",
-          "dev": true,
-          "requires": {
-            "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz"
-          }
+          "dev": true
         },
         "babel-plugin-transform-es2015-parameters": {
           "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.18.0.tgz",
           "integrity": "sha1-myz+I4xUnxY1uif8HaqFi+cGCLE=",
-          "dev": true,
-          "requires": {
-            "babel-helper-call-delegate": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.18.0.tgz",
-            "babel-helper-get-function-arity": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.18.0.tgz",
-            "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
-            "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
-            "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.19.0.tgz",
-            "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz"
-          }
+          "dev": true
         }
       }
     },
     "babel-preset-es2016": {
       "version": "https://registry.npmjs.org/babel-preset-es2016/-/babel-preset-es2016-6.16.0.tgz",
       "integrity": "sha1-x9r1/u3u6ZyGeBO98NVz2UyhKBI=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-transform-exponentiation-operator": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.8.0.tgz"
-      }
+      "dev": true
     },
     "babel-preset-es2017": {
       "version": "https://registry.npmjs.org/babel-preset-es2017/-/babel-preset-es2017-6.16.0.tgz",
       "integrity": "sha1-U2xih3eKdYlI3dCStGa271C3hvo=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-syntax-trailing-function-commas": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.13.0.tgz",
-        "babel-plugin-transform-async-to-generator": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.16.0.tgz"
-      }
+      "dev": true
     },
     "babel-preset-jest": {
       "version": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-16.0.0.tgz",
       "integrity": "sha1-QXqrwtfZMXD0PCDvHqAUXo9/LbU=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-jest-hoist": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-16.0.0.tgz"
-      }
+      "dev": true
     },
     "babel-preset-latest": {
       "version": "https://registry.npmjs.org/babel-preset-latest/-/babel-preset-latest-6.16.0.tgz",
       "integrity": "sha1-W4fhniULsSE/E69Oydx6UdU/OI0=",
-      "dev": true,
-      "requires": {
-        "babel-preset-es2015": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.18.0.tgz",
-        "babel-preset-es2016": "https://registry.npmjs.org/babel-preset-es2016/-/babel-preset-es2016-6.16.0.tgz",
-        "babel-preset-es2017": "https://registry.npmjs.org/babel-preset-es2017/-/babel-preset-es2017-6.16.0.tgz"
-      }
+      "dev": true
     },
     "babel-preset-react": {
       "version": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.16.0.tgz",
       "integrity": "sha1-qhF9YN4JKGB+NDxIKJBuRmGCQxY=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-syntax-flow": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
-        "babel-plugin-syntax-jsx": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-        "babel-plugin-transform-flow-strip-types": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.18.0.tgz",
-        "babel-plugin-transform-react-display-name": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.8.0.tgz",
-        "babel-plugin-transform-react-jsx": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.8.0.tgz",
-        "babel-plugin-transform-react-jsx-self": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.11.0.tgz",
-        "babel-plugin-transform-react-jsx-source": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.9.0.tgz"
-      }
+      "dev": true
     },
     "babel-preset-react-app": {
       "version": "https://registry.npmjs.org/babel-preset-react-app/-/babel-preset-react-app-1.0.0.tgz",
       "integrity": "sha1-52E1AIWdlvF3uno4o+0Kkj7lDag=",
       "dev": true,
-      "requires": {
-        "babel-plugin-transform-class-properties": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.16.0.tgz",
-        "babel-plugin-transform-es2015-destructuring": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.16.0.tgz",
-        "babel-plugin-transform-es2015-parameters": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.17.0.tgz",
-        "babel-plugin-transform-object-rest-spread": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.16.0.tgz",
-        "babel-plugin-transform-react-constant-elements": "https://registry.npmjs.org/babel-plugin-transform-react-constant-elements/-/babel-plugin-transform-react-constant-elements-6.9.1.tgz",
-        "babel-plugin-transform-react-jsx-self": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.11.0.tgz",
-        "babel-plugin-transform-react-jsx-source": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.9.0.tgz",
-        "babel-plugin-transform-regenerator": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.16.1.tgz",
-        "babel-plugin-transform-runtime": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.15.0.tgz",
-        "babel-preset-env": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-0.0.6.tgz",
-        "babel-preset-latest": "https://registry.npmjs.org/babel-preset-latest/-/babel-preset-latest-6.16.0.tgz",
-        "babel-preset-react": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.16.0.tgz",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.11.6.tgz"
-      },
       "dependencies": {
         "babel-runtime": {
           "version": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.11.6.tgz",
           "integrity": "sha1-bbcH/vLUnEm/o8tk79tDa1GLgiI=",
-          "dev": true,
-          "requires": {
-            "core-js": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-            "regenerator-runtime": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz"
-          }
+          "dev": true
         },
         "core-js": {
           "version": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
@@ -1069,41 +618,11 @@
       "version": "https://registry.npmjs.org/babel-register/-/babel-register-6.18.0.tgz",
       "integrity": "sha1-iS4uA4ZQeN2QrSxxURHsREmzKmg=",
       "dev": true,
-      "requires": {
-        "babel-core": "https://registry.npmjs.org/babel-core/-/babel-core-6.18.2.tgz",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
-        "core-js": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-        "home-or-tmp": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
-        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-        "source-map-support": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.6.tgz"
-      },
       "dependencies": {
         "babel-core": {
           "version": "https://registry.npmjs.org/babel-core/-/babel-core-6.18.2.tgz",
           "integrity": "sha1-2LsU3WmG+k81ZqJs7aOWT6DgTls=",
-          "dev": true,
-          "requires": {
-            "babel-code-frame": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-            "babel-generator": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.19.0.tgz",
-            "babel-helpers": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.16.0.tgz",
-            "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-            "babel-register": "https://registry.npmjs.org/babel-register/-/babel-register-6.18.0.tgz",
-            "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
-            "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
-            "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.19.0.tgz",
-            "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-            "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
-            "convert-source-map": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.3.0.tgz",
-            "debug": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-            "json5": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "private": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
-            "slash": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
-          }
+          "dev": true
         },
         "core-js": {
           "version": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
@@ -1121,10 +640,6 @@
       "version": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
       "integrity": "sha1-D0F3/9mEku8Tufgj6ZlKAlhMkHg=",
       "dev": true,
-      "requires": {
-        "core-js": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-        "regenerator-runtime": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz"
-      },
       "dependencies": {
         "core-js": {
           "version": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
@@ -1140,41 +655,17 @@
     "babel-template": {
       "version": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
       "integrity": "sha1-4UndGp8Do1+BfdvE0EgZiOfryMo=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
-        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.19.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-        "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
-        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
-      }
+      "dev": true
     },
     "babel-traverse": {
       "version": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.19.0.tgz",
       "integrity": "sha1-aDY/uCHiYkfVKlGahLLOq4309Vo=",
-      "dev": true,
-      "requires": {
-        "babel-code-frame": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-        "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-        "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-        "globals": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz",
-        "invariant": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
-      }
+      "dev": true
     },
     "babel-types": {
       "version": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
       "integrity": "sha1-jbKXLb7QHxGSqLYCuh4eTFFiQLk=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
-        "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-        "to-fast-properties": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
-      }
+      "dev": true
     },
     "babylon": {
       "version": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
@@ -1205,10 +696,7 @@
       "version": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
       "integrity": "sha1-PKdrhSQccXC/fZcD57mqdGMAQNQ=",
       "dev": true,
-      "optional": true,
-      "requires": {
-        "tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
-      }
+      "optional": true
     },
     "big.js": {
       "version": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
@@ -1233,71 +721,42 @@
     "boom": {
       "version": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "dev": true,
-      "requires": {
-        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-      }
+      "dev": true
     },
     "brace-expansion": {
       "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
       "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
-      "dev": true,
-      "requires": {
-        "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-        "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-      }
+      "dev": true
     },
     "braces": {
       "version": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-      "dev": true,
-      "requires": {
-        "expand-range": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-        "preserve": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-        "repeat-element": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
-      }
+      "dev": true
     },
     "browser-resolve": {
       "version": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
       "integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
-      "dev": true,
-      "requires": {
-        "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
-      }
+      "dev": true
     },
     "browserify-zlib": {
       "version": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
       "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
-      "dev": true,
-      "requires": {
-        "pako": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz"
-      }
+      "dev": true
     },
     "browserslist": {
       "version": "https://registry.npmjs.org/browserslist/-/browserslist-1.4.0.tgz",
       "integrity": "sha1-nP3PU4TZFY9bcNoqoAsw6P8BkEk=",
-      "dev": true,
-      "requires": {
-        "caniuse-db": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000588.tgz"
-      }
+      "dev": true
     },
     "bser": {
       "version": "https://registry.npmjs.org/bser/-/bser-1.0.2.tgz",
       "integrity": "sha1-OBEWlwsqbe6lZG3RXdcnhES1YWk=",
-      "dev": true,
-      "requires": {
-        "node-int64": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz"
-      }
+      "dev": true
     },
     "buffer": {
       "version": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
-      "dev": true,
-      "requires": {
-        "base64-js": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz",
-        "ieee754": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
-        "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-      }
+      "dev": true
     },
     "buffer-shims": {
       "version": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
@@ -1317,10 +776,7 @@
     "caller-path": {
       "version": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-      "dev": true,
-      "requires": {
-        "callsites": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz"
-      }
+      "dev": true
     },
     "callsites": {
       "version": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
@@ -1330,11 +786,7 @@
     "camel-case": {
       "version": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
       "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
-      "dev": true,
-      "requires": {
-        "no-case": "https://registry.npmjs.org/no-case/-/no-case-2.3.0.tgz",
-        "upper-case": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz"
-      }
+      "dev": true
     },
     "camelcase": {
       "version": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
@@ -1349,11 +801,7 @@
     "cardinal": {
       "version": "https://registry.npmjs.org/cardinal/-/cardinal-1.0.0.tgz",
       "integrity": "sha1-UOIcGwqjdyn5N33vGWtanOyTLuk=",
-      "dev": true,
-      "requires": {
-        "ansicolors": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
-        "redeyed": "https://registry.npmjs.org/redeyed/-/redeyed-1.0.1.tgz"
-      }
+      "dev": true
     },
     "case-sensitive-paths-webpack-plugin": {
       "version": "https://registry.npmjs.org/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-1.1.4.tgz",
@@ -1368,23 +816,12 @@
     "center-align": {
       "version": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "dev": true,
-      "requires": {
-        "align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
-      }
+      "dev": true
     },
     "chalk": {
       "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
-      "requires": {
-        "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-        "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-        "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-      },
       "dependencies": {
         "supports-color": {
           "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
@@ -1396,18 +833,7 @@
     "chokidar": {
       "version": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz",
       "integrity": "sha1-L0RHq16W5Q+z14n9kNTHLg5McMI=",
-      "dev": true,
-      "requires": {
-        "anymatch": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
-        "async-each": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-        "fsevents": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.14.tgz",
-        "glob-parent": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-        "is-binary-path": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-        "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-        "readdirp": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz"
-      }
+      "dev": true
     },
     "ci-info": {
       "version": "https://registry.npmjs.org/ci-info/-/ci-info-1.0.0.tgz",
@@ -1422,10 +848,7 @@
     "clap": {
       "version": "https://registry.npmjs.org/clap/-/clap-1.1.1.tgz",
       "integrity": "sha1-qKk+C/t1gawZnE8AGlUlpyTOaW0=",
-      "dev": true,
-      "requires": {
-        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
-      }
+      "dev": true
     },
     "classnames": {
       "version": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
@@ -1435,36 +858,23 @@
       "version": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.21.tgz",
       "integrity": "sha1-IQHV29GdY9vBanXr1XDnwzlI9ls=",
       "dev": true,
-      "requires": {
-        "commander": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
-      },
       "dependencies": {
         "source-map": {
           "version": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true,
-          "requires": {
-            "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
-          }
+          "dev": true
         }
       }
     },
     "cli-cursor": {
       "version": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-      "dev": true,
-      "requires": {
-        "restore-cursor": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz"
-      }
+      "dev": true
     },
     "cli-table": {
       "version": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
       "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
       "dev": true,
-      "requires": {
-        "colors": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
-      },
       "dependencies": {
         "colors": {
           "version": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
@@ -1476,11 +886,7 @@
     "cli-usage": {
       "version": "https://registry.npmjs.org/cli-usage/-/cli-usage-0.1.4.tgz",
       "integrity": "sha1-fAHg3HBsI0s5yTODjI4gshdXduI=",
-      "dev": true,
-      "requires": {
-        "marked": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
-        "marked-terminal": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-1.7.0.tgz"
-      }
+      "dev": true
     },
     "cli-width": {
       "version": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
@@ -1491,11 +897,6 @@
       "version": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "dev": true,
-      "requires": {
-        "center-align": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-        "right-align": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-        "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-      },
       "dependencies": {
         "wordwrap": {
           "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
@@ -1517,10 +918,7 @@
     "coa": {
       "version": "https://registry.npmjs.org/coa/-/coa-1.0.1.tgz",
       "integrity": "sha1-f5WTRs/IcZ4/cjPNaFKFSnxn2KM=",
-      "dev": true,
-      "requires": {
-        "q": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
-      }
+      "dev": true
     },
     "code-point-at": {
       "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -1534,20 +932,12 @@
     "color": {
       "version": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
       "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
-      "dev": true,
-      "requires": {
-        "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-        "color-convert": "https://registry.npmjs.org/color-convert/-/color-convert-1.8.2.tgz",
-        "color-string": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz"
-      }
+      "dev": true
     },
     "color-convert": {
       "version": "https://registry.npmjs.org/color-convert/-/color-convert-1.8.2.tgz",
       "integrity": "sha1-voaBhNfIYxdm1U5weOJnLXx+Mzk=",
-      "dev": true,
-      "requires": {
-        "color-name": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz"
-      }
+      "dev": true
     },
     "color-name": {
       "version": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
@@ -1557,20 +947,12 @@
     "color-string": {
       "version": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
       "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
-      "dev": true,
-      "requires": {
-        "color-name": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz"
-      }
+      "dev": true
     },
     "colormin": {
       "version": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
       "integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
-      "dev": true,
-      "requires": {
-        "color": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
-        "css-color-names": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
-        "has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz"
-      }
+      "dev": true
     },
     "colors": {
       "version": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
@@ -1580,18 +962,12 @@
     "combined-stream": {
       "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-      "dev": true,
-      "requires": {
-        "delayed-stream": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-      }
+      "dev": true
     },
     "commander": {
       "version": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
       "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
-      "dev": true,
-      "requires": {
-        "graceful-readlink": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-      }
+      "dev": true
     },
     "commondir": {
       "version": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -1601,31 +977,17 @@
     "compressible": {
       "version": "https://registry.npmjs.org/compressible/-/compressible-2.0.9.tgz",
       "integrity": "sha1-baq04rWZwncN2eIeeokbHFp1VCU=",
-      "dev": true,
-      "requires": {
-        "mime-db": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz"
-      }
+      "dev": true
     },
     "compression": {
       "version": "https://registry.npmjs.org/compression/-/compression-1.6.2.tgz",
       "integrity": "sha1-zOsSHsydCcUtetDDNQ6pPd1AK8M=",
       "dev": true,
-      "requires": {
-        "accepts": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
-        "bytes": "https://registry.npmjs.org/bytes/-/bytes-2.3.0.tgz",
-        "compressible": "https://registry.npmjs.org/compressible/-/compressible-2.0.9.tgz",
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-        "on-headers": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
-        "vary": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz"
-      },
       "dependencies": {
         "debug": {
           "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-          }
+          "dev": true
         },
         "ms": {
           "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
@@ -1643,24 +1005,11 @@
       "version": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
       "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
       "dev": true,
-      "requires": {
-        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-        "typedarray": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
-      },
       "dependencies": {
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-          }
+          "dev": true
         }
       }
     },
@@ -1672,10 +1021,7 @@
     "console-browserify": {
       "version": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
-      "dev": true,
-      "requires": {
-        "date-now": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
-      }
+      "dev": true
     },
     "constants-browserify": {
       "version": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
@@ -1730,15 +1076,6 @@
       "version": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.1.0.tgz",
       "integrity": "sha1-JuOEogVepOCHBQ5eCNU+tOrI+G4=",
       "dev": true,
-      "requires": {
-        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-        "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
-        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-        "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-        "parse-json": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-        "require-from-string": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz"
-      },
       "dependencies": {
         "minimist": {
           "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -1750,29 +1087,17 @@
     "cross-spawn": {
       "version": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
       "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
-      "dev": true,
-      "requires": {
-        "lru-cache": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
-        "which": "https://registry.npmjs.org/which/-/which-1.2.12.tgz"
-      }
+      "dev": true
     },
     "cryptiles": {
       "version": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "dev": true,
-      "requires": {
-        "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-      }
+      "dev": true
     },
     "crypto-browserify": {
       "version": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.8.tgz",
       "integrity": "sha1-ubEdvm2WUd2IKgHmzEZ99xjs8Yk=",
-      "dev": true,
-      "requires": {
-        "pbkdf2-compat": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz",
-        "ripemd160": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz",
-        "sha.js": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz"
-      }
+      "dev": true
     },
     "css-color-names": {
       "version": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
@@ -1782,52 +1107,22 @@
     "css-loader": {
       "version": "https://registry.npmjs.org/css-loader/-/css-loader-0.25.0.tgz",
       "integrity": "sha1-w/68jOKPTINXa2sTcH9H+Qw5AiM=",
-      "dev": true,
-      "requires": {
-        "babel-code-frame": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-        "css-selector-tokenizer": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.6.0.tgz",
-        "cssnano": "https://registry.npmjs.org/cssnano/-/cssnano-3.8.1.tgz",
-        "loader-utils": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.16.tgz",
-        "lodash.camelcase": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-3.0.1.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.6.tgz",
-        "postcss-modules-extract-imports": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.0.1.tgz",
-        "postcss-modules-local-by-default": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.1.1.tgz",
-        "postcss-modules-scope": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.0.2.tgz",
-        "postcss-modules-values": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.2.2.tgz",
-        "source-list-map": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.6.tgz"
-      }
+      "dev": true
     },
     "css-select": {
       "version": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
-      "dev": true,
-      "requires": {
-        "boolbase": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-        "css-what": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
-        "domutils": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-        "nth-check": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz"
-      }
+      "dev": true
     },
     "css-selector-tokenizer": {
       "version": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.6.0.tgz",
       "integrity": "sha1-ZEX1gseTDSQdzFAHpD1vy48HMVI=",
       "dev": true,
-      "requires": {
-        "cssesc": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
-        "fastparse": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
-        "regexpu-core": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz"
-      },
       "dependencies": {
         "regexpu-core": {
           "version": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
           "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
-          "dev": true,
-          "requires": {
-            "regenerate": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
-            "regjsgen": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-            "regjsparser": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz"
-          }
+          "dev": true
         }
       }
     },
@@ -1844,50 +1139,12 @@
     "cssnano": {
       "version": "https://registry.npmjs.org/cssnano/-/cssnano-3.8.1.tgz",
       "integrity": "sha1-AIpIIUjulIzwry7m5EvZfFP4huw=",
-      "dev": true,
-      "requires": {
-        "autoprefixer": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.5.1.tgz",
-        "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-        "defined": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-        "has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.6.tgz",
-        "postcss-calc": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
-        "postcss-colormin": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.1.tgz",
-        "postcss-convert-values": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.5.0.tgz",
-        "postcss-discard-comments": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
-        "postcss-discard-duplicates": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.0.2.tgz",
-        "postcss-discard-empty": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
-        "postcss-discard-overridden": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
-        "postcss-discard-unused": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
-        "postcss-filter-plugins": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
-        "postcss-merge-idents": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
-        "postcss-merge-longhand": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.1.tgz",
-        "postcss-merge-rules": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.0.10.tgz",
-        "postcss-minify-font-values": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
-        "postcss-minify-gradients": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
-        "postcss-minify-params": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.0.5.tgz",
-        "postcss-minify-selectors": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.0.7.tgz",
-        "postcss-normalize-charset": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
-        "postcss-normalize-url": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.7.tgz",
-        "postcss-ordered-values": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.2.tgz",
-        "postcss-reduce-idents": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.3.1.tgz",
-        "postcss-reduce-initial": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.0.tgz",
-        "postcss-reduce-transforms": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
-        "postcss-svgo": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.5.tgz",
-        "postcss-unique-selectors": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
-        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
-        "postcss-zindex": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz"
-      }
+      "dev": true
     },
     "csso": {
       "version": "https://registry.npmjs.org/csso/-/csso-2.2.1.tgz",
       "integrity": "sha1-Ufu1NH5Q6B5u1RZopISQrm/ir+I=",
-      "dev": true,
-      "requires": {
-        "clap": "https://registry.npmjs.org/clap/-/clap-1.1.1.tgz",
-        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
-      }
+      "dev": true
     },
     "cssom": {
       "version": "https://registry.npmjs.org/cssom/-/cssom-0.3.1.tgz",
@@ -1897,18 +1154,12 @@
     "cssstyle": {
       "version": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
       "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
-      "dev": true,
-      "requires": {
-        "cssom": "https://registry.npmjs.org/cssom/-/cssom-0.3.1.tgz"
-      }
+      "dev": true
     },
     "d": {
       "version": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
       "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
-      "dev": true,
-      "requires": {
-        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz"
-      }
+      "dev": true
     },
     "damerau-levenshtein": {
       "version": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.3.tgz",
@@ -1919,9 +1170,6 @@
       "version": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
-      "requires": {
-        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-      },
       "dependencies": {
         "assert-plus": {
           "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -1938,15 +1186,22 @@
     "debug": {
       "version": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
       "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-      "dev": true,
-      "requires": {
-        "ms": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
-      }
+      "dev": true
     },
     "decamelize": {
       "version": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+    },
+    "deep-freeze": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/deep-freeze/-/deep-freeze-0.0.1.tgz",
+      "integrity": "sha1-OgsABd4YZygZ39OM0x+RF5yJPoQ="
     },
     "deep-is": {
       "version": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -1956,11 +1211,7 @@
     "define-properties": {
       "version": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
-      "dev": true,
-      "requires": {
-        "foreach": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-        "object-keys": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz"
-      }
+      "dev": true
     },
     "defined": {
       "version": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
@@ -1970,16 +1221,7 @@
     "del": {
       "version": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-      "dev": true,
-      "requires": {
-        "globby": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-        "is-path-cwd": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-        "is-path-in-cwd": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-        "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz"
-      }
+      "dev": true
     },
     "delayed-stream": {
       "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -1999,18 +1241,12 @@
     "detect-indent": {
       "version": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-      "dev": true,
-      "requires": {
-        "repeating": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz"
-      }
+      "dev": true
     },
     "detect-port": {
       "version": "https://registry.npmjs.org/detect-port/-/detect-port-1.0.1.tgz",
       "integrity": "sha1-Phqmp/9md7tgiUspEXJSnYgMHoU=",
-      "dev": true,
-      "requires": {
-        "commander": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz"
-      }
+      "dev": true
     },
     "diff": {
       "version": "https://registry.npmjs.org/diff/-/diff-3.1.0.tgz",
@@ -2020,19 +1256,12 @@
     "doctrine": {
       "version": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
       "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
-      "dev": true,
-      "requires": {
-        "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-        "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-      }
+      "dev": true
     },
     "dom-converter": {
       "version": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.1.4.tgz",
       "integrity": "sha1-pF71cnuJDJv/5tfIduexnLDhfzs=",
       "dev": true,
-      "requires": {
-        "utila": "https://registry.npmjs.org/utila/-/utila-0.3.3.tgz"
-      },
       "dependencies": {
         "utila": {
           "version": "https://registry.npmjs.org/utila/-/utila-0.3.3.tgz",
@@ -2045,10 +1274,6 @@
       "version": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "dev": true,
-      "requires": {
-        "domelementtype": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-        "entities": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
-      },
       "dependencies": {
         "domelementtype": {
           "version": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
@@ -2070,11 +1295,7 @@
     "domutils": {
       "version": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-      "dev": true,
-      "requires": {
-        "dom-serializer": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-        "domelementtype": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
-      }
+      "dev": true
     },
     "dotenv": {
       "version": "https://registry.npmjs.org/dotenv/-/dotenv-2.0.0.tgz",
@@ -2090,10 +1311,7 @@
       "version": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "dev": true,
-      "optional": true,
-      "requires": {
-        "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
-      }
+      "optional": true
     },
     "ee-first": {
       "version": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -2112,20 +1330,12 @@
     },
     "encoding": {
       "version": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "requires": {
-        "iconv-lite": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz"
-      }
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s="
     },
     "enhanced-resolve": {
       "version": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
       "integrity": "sha1-TW5omzcl+GCQknzMhs2fFjW4ni4=",
       "dev": true,
-      "requires": {
-        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-        "memory-fs": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz",
-        "tapable": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz"
-      },
       "dependencies": {
         "memory-fs": {
           "version": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz",
@@ -2142,18 +1352,6 @@
     "enzyme": {
       "version": "https://registry.npmjs.org/enzyme/-/enzyme-2.6.0.tgz",
       "integrity": "sha1-FI10KyXiVl9+gIcKDJKuqb4bkOo=",
-      "requires": {
-        "cheerio": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
-        "function.prototype.name": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.0.0.tgz",
-        "in-publish": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
-        "is-subset": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-        "object-is": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
-        "object.assign": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz",
-        "object.entries": "https://registry.npmjs.org/object.entries/-/object.entries-1.0.3.tgz",
-        "object.values": "https://registry.npmjs.org/object.values/-/object.values-1.0.3.tgz",
-        "uuid": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz"
-      },
       "dependencies": {
         "abbrev": {
           "version": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
@@ -12523,103 +11721,52 @@
     "errno": {
       "version": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
       "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
-      "dev": true,
-      "requires": {
-        "prr": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
-      }
+      "dev": true
     },
     "error-ex": {
       "version": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
       "integrity": "sha1-5ntD8+gsluo6WE/+4Ln8MyXYAtk=",
-      "dev": true,
-      "requires": {
-        "is-arrayish": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
-      }
+      "dev": true
     },
     "es-abstract": {
       "version": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.6.1.tgz",
       "integrity": "sha1-u4ogZBIKvPkooIbqPZBDEUKF7Jk=",
-      "dev": true,
-      "requires": {
-        "es-to-primitive": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
-        "function-bind": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
-        "is-callable": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-        "is-regex": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.3.tgz"
-      }
+      "dev": true
     },
     "es-to-primitive": {
       "version": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
-      "dev": true,
-      "requires": {
-        "is-callable": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-        "is-date-object": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-        "is-symbol": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz"
-      }
+      "dev": true
     },
     "es5-ext": {
       "version": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz",
       "integrity": "sha1-qoRkHU23a2Krul5F/YBey6sUAEc=",
-      "dev": true,
-      "requires": {
-        "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
-        "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz"
-      }
+      "dev": true
     },
     "es6-iterator": {
       "version": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
       "integrity": "sha1-vZaFZ9YWNeM8C4BydhPJy0sJa6w=",
-      "dev": true,
-      "requires": {
-        "d": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz",
-        "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz"
-      }
+      "dev": true
     },
     "es6-map": {
       "version": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.4.tgz",
       "integrity": "sha1-o0sUe+IkdzpNfagHJ5TO+jYyuJc=",
-      "dev": true,
-      "requires": {
-        "d": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz",
-        "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
-        "es6-set": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.4.tgz",
-        "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz",
-        "event-emitter": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz"
-      }
+      "dev": true
     },
     "es6-set": {
       "version": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.4.tgz",
       "integrity": "sha1-lRa2dhwpZLkv9HlFYjOiR9xwfOg=",
-      "dev": true,
-      "requires": {
-        "d": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz",
-        "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
-        "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz",
-        "event-emitter": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz"
-      }
+      "dev": true
     },
     "es6-symbol": {
       "version": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz",
       "integrity": "sha1-lEgcZV56fK2C66gy2X1UM0ltf/o=",
-      "dev": true,
-      "requires": {
-        "d": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz"
-      }
+      "dev": true
     },
     "es6-weak-map": {
       "version": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.1.tgz",
       "integrity": "sha1-DSu9iCfrX7S6j5f7/qUNQ9sh6oE=",
-      "dev": true,
-      "requires": {
-        "d": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz",
-        "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
-        "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz"
-      }
+      "dev": true
     },
     "escape-html": {
       "version": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -12635,13 +11782,6 @@
       "version": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
       "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
       "dev": true,
-      "requires": {
-        "esprima": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-        "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-        "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-        "optionator": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz"
-      },
       "dependencies": {
         "estraverse": {
           "version": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
@@ -12652,63 +11792,19 @@
           "version": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
           "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
-          }
+          "optional": true
         }
       }
     },
     "escope": {
       "version": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
-      "dev": true,
-      "requires": {
-        "es6-map": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.4.tgz",
-        "es6-weak-map": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.1.tgz",
-        "esrecurse": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
-        "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
-      }
+      "dev": true
     },
     "eslint": {
       "version": "https://registry.npmjs.org/eslint/-/eslint-3.8.1.tgz",
       "integrity": "sha1-fQLbRM1ar0+nqkieHwg7qkVDQro=",
       "dev": true,
-      "requires": {
-        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-        "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-        "doctrine": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-        "escope": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
-        "espree": "https://registry.npmjs.org/espree/-/espree-3.3.2.tgz",
-        "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-        "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-        "file-entry-cache": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-        "globals": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz",
-        "ignore": "https://registry.npmjs.org/ignore/-/ignore-3.2.0.tgz",
-        "imurmurhash": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-        "inquirer": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
-        "is-my-json-valid": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
-        "is-resolvable": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
-        "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
-        "json-stable-stringify": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-        "levn": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-        "natural-compare": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-        "optionator": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-        "path-is-inside": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-        "pluralize": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
-        "progress": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-        "require-uncached": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-        "shelljs": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
-        "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-        "strip-json-comments": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-        "table": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
-        "text-table": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-        "user-home": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz"
-      },
       "dependencies": {
         "strip-bom": {
           "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -12725,39 +11821,22 @@
     "eslint-import-resolver-node": {
       "version": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.2.3.tgz",
       "integrity": "sha1-Wt2BBujJKNssuiMrzZ76hG49oWw=",
-      "dev": true,
-      "requires": {
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-        "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
-      }
+      "dev": true
     },
     "eslint-loader": {
       "version": "https://registry.npmjs.org/eslint-loader/-/eslint-loader-1.6.0.tgz",
       "integrity": "sha1-OPmh5sYCpPHz81FiiXJuXSbm4WU=",
-      "dev": true,
-      "requires": {
-        "find-cache-dir": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
-        "loader-utils": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.16.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
-      }
+      "dev": true
     },
     "eslint-module-utils": {
       "version": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-1.0.0.tgz",
       "integrity": "sha1-xKV/06U+/YQmzC1VUKraubvQX9A=",
       "dev": true,
-      "requires": {
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-        "pkg-dir": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz"
-      },
       "dependencies": {
         "debug": {
           "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-          }
+          "dev": true
         },
         "ms": {
           "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
@@ -12769,66 +11848,34 @@
     "eslint-plugin-flowtype": {
       "version": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.21.0.tgz",
       "integrity": "sha1-pH6Fq83RgdN6M2BUvVUhSa44fZw=",
-      "dev": true,
-      "requires": {
-        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
-      }
+      "dev": true
     },
     "eslint-plugin-import": {
       "version": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.0.1.tgz",
       "integrity": "sha1-3P6WNX1Haz+CJXDULCm+xm9dnFw=",
       "dev": true,
-      "requires": {
-        "builtin-modules": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-        "contains-path": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-        "doctrine": "https://registry.npmjs.org/doctrine/-/doctrine-1.3.0.tgz",
-        "eslint-import-resolver-node": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.2.3.tgz",
-        "eslint-module-utils": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-1.0.0.tgz",
-        "has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
-        "lodash.cond": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
-        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-        "pkg-up": "https://registry.npmjs.org/pkg-up/-/pkg-up-1.0.0.tgz"
-      },
       "dependencies": {
         "doctrine": {
           "version": "https://registry.npmjs.org/doctrine/-/doctrine-1.3.0.tgz",
           "integrity": "sha1-E+dWgrVVGEJCdvfBc3g0Vu+RPSY=",
-          "dev": true,
-          "requires": {
-            "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-          }
+          "dev": true
         }
       }
     },
     "eslint-plugin-jsx-a11y": {
       "version": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-2.2.3.tgz",
       "integrity": "sha1-TjXLcbin23AqxBXIBuuOjZ6mxl0=",
-      "dev": true,
-      "requires": {
-        "damerau-levenshtein": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.3.tgz",
-        "jsx-ast-utils": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.3.4.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
-      }
+      "dev": true
     },
     "eslint-plugin-react": {
       "version": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-6.4.1.tgz",
       "integrity": "sha1-fRqt50fbFYkvce7h/qSt35e8+is=",
-      "dev": true,
-      "requires": {
-        "doctrine": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-        "jsx-ast-utils": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.3.4.tgz"
-      }
+      "dev": true
     },
     "espree": {
       "version": "https://registry.npmjs.org/espree/-/espree-3.3.2.tgz",
       "integrity": "sha1-2/P63rTstNR3gwPlAQOz02yIuJw=",
-      "dev": true,
-      "requires": {
-        "acorn": "https://registry.npmjs.org/acorn/-/acorn-4.0.3.tgz",
-        "acorn-jsx": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz"
-      }
+      "dev": true
     },
     "esprima": {
       "version": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
@@ -12839,10 +11886,6 @@
       "version": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
       "integrity": "sha1-RxO2U2rffyrE8yfVWed1a/9kgiA=",
       "dev": true,
-      "requires": {
-        "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
-      },
       "dependencies": {
         "estraverse": {
           "version": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
@@ -12869,11 +11912,7 @@
     "event-emitter": {
       "version": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz",
       "integrity": "sha1-jWPd+0z+H647MsomXExyAiIIC7U=",
-      "dev": true,
-      "requires": {
-        "d": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz"
-      }
+      "dev": true
     },
     "eventemitter3": {
       "version": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
@@ -12888,18 +11927,12 @@
     "eventsource": {
       "version": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
       "integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
-      "dev": true,
-      "requires": {
-        "original": "https://registry.npmjs.org/original/-/original-1.0.0.tgz"
-      }
+      "dev": true
     },
     "exec-sh": {
       "version": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.0.tgz",
       "integrity": "sha1-FPdd4/INKG75MwmbLOUKkDWc7xA=",
-      "dev": true,
-      "requires": {
-        "merge": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz"
-      }
+      "dev": true
     },
     "exit-hook": {
       "version": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
@@ -12909,73 +11942,27 @@
     "expand-brackets": {
       "version": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-      "dev": true,
-      "requires": {
-        "is-posix-bracket": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
-      }
+      "dev": true
     },
     "expand-range": {
       "version": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-      "dev": true,
-      "requires": {
-        "fill-range": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz"
-      }
+      "dev": true
     },
     "expect": {
       "version": "https://registry.npmjs.org/expect/-/expect-1.20.2.tgz",
       "integrity": "sha1-1Fj+TFYAQDa64yMkFqP2Nh8E+WU=",
-      "dev": true,
-      "requires": {
-        "define-properties": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-        "has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
-        "is-equal": "https://registry.npmjs.org/is-equal/-/is-equal-1.5.3.tgz",
-        "is-regex": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.3.tgz",
-        "object-inspect": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.2.1.tgz",
-        "object-keys": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-        "tmatch": "https://registry.npmjs.org/tmatch/-/tmatch-2.0.1.tgz"
-      }
+      "dev": true
     },
     "express": {
       "version": "https://registry.npmjs.org/express/-/express-4.14.0.tgz",
       "integrity": "sha1-we4/Qs3Ikfs9xlCoki1R7IR9DWY=",
       "dev": true,
-      "requires": {
-        "accepts": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
-        "array-flatten": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-        "content-disposition": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz",
-        "content-type": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
-        "cookie": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-        "cookie-signature": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-        "depd": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
-        "encodeurl": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
-        "escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-        "etag": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
-        "finalhandler": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
-        "fresh": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
-        "merge-descriptors": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-        "methods": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-        "on-finished": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-        "parseurl": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
-        "path-to-regexp": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-        "proxy-addr": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.2.tgz",
-        "qs": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz",
-        "range-parser": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-        "send": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
-        "serve-static": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz",
-        "type-is": "https://registry.npmjs.org/type-is/-/type-is-1.6.14.tgz",
-        "utils-merge": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
-        "vary": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz"
-      },
       "dependencies": {
         "debug": {
           "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-          }
+          "dev": true
         },
         "ms": {
           "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
@@ -12997,20 +11984,12 @@
     "extglob": {
       "version": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-      "dev": true,
-      "requires": {
-        "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
-      }
+      "dev": true
     },
     "extract-text-webpack-plugin": {
       "version": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-1.0.1.tgz",
       "integrity": "sha1-yVvzy6rEnclvHcbgclSfu2VMzSw=",
-      "dev": true,
-      "requires": {
-        "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-        "loader-utils": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.16.tgz",
-        "webpack-sources": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.1.3.tgz"
-      }
+      "dev": true
     },
     "extsprintf": {
       "version": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
@@ -13030,56 +12009,31 @@
     "faye-websocket": {
       "version": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.7.3.tgz",
       "integrity": "sha1-zEB0x/Sk39A69U3WXDVLE1EyzhE=",
-      "dev": true,
-      "requires": {
-        "websocket-driver": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz"
-      }
+      "dev": true
     },
     "fb-watchman": {
       "version": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-1.9.0.tgz",
       "integrity": "sha1-byaPHzR6azyHXR6J2n4e15rfwOw=",
-      "dev": true,
-      "requires": {
-        "bser": "https://registry.npmjs.org/bser/-/bser-1.0.2.tgz"
-      }
+      "dev": true
     },
     "fbjs": {
       "version": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.6.tgz",
-      "integrity": "sha1-frZ9aYay1QB6m26S4OfLb3XK0pA=",
-      "requires": {
-        "core-js": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-        "isomorphic-fetch": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-        "loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-        "promise": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
-        "ua-parser-js": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.12.tgz"
-      }
+      "integrity": "sha1-frZ9aYay1QB6m26S4OfLb3XK0pA="
     },
     "figures": {
       "version": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-      "dev": true,
-      "requires": {
-        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
-      }
+      "dev": true
     },
     "file-entry-cache": {
       "version": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
-      "dev": true,
-      "requires": {
-        "flat-cache": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.1.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
-      }
+      "dev": true
     },
     "file-loader": {
       "version": "https://registry.npmjs.org/file-loader/-/file-loader-0.9.0.tgz",
       "integrity": "sha1-HS2t3UJM5tGwfP4/eXMb7TYXq0I=",
-      "dev": true,
-      "requires": {
-        "loader-utils": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.16.tgz"
-      }
+      "dev": true
     },
     "filename-regex": {
       "version": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
@@ -13090,30 +12044,16 @@
       "version": "https://registry.npmjs.org/fileset/-/fileset-0.2.1.tgz",
       "integrity": "sha1-WI74lzxmI7KnbfRlEFaWuWqsgGc=",
       "dev": true,
-      "requires": {
-        "glob": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
-      },
       "dependencies": {
         "glob": {
           "version": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true,
-          "requires": {
-            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-          }
+          "dev": true
         },
         "minimatch": {
           "version": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
-          }
+          "dev": true
         }
       }
     },
@@ -13125,34 +12065,17 @@
     "fill-range": {
       "version": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-      "dev": true,
-      "requires": {
-        "is-number": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-        "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-        "randomatic": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
-        "repeat-element": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-        "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
-      }
+      "dev": true
     },
     "finalhandler": {
       "version": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
       "integrity": "sha1-6VCKvs6bbbqHGmlCodeRG5GRGsc=",
       "dev": true,
-      "requires": {
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-        "escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-        "on-finished": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-        "statuses": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-        "unpipe": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
-      },
       "dependencies": {
         "debug": {
           "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-          }
+          "dev": true
         },
         "ms": {
           "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
@@ -13164,32 +12087,17 @@
     "find-cache-dir": {
       "version": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
       "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
-      "dev": true,
-      "requires": {
-        "commondir": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-        "pkg-dir": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz"
-      }
+      "dev": true
     },
     "find-up": {
       "version": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-      "dev": true,
-      "requires": {
-        "path-exists": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
-      }
+      "dev": true
     },
     "flat-cache": {
       "version": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.1.tgz",
       "integrity": "sha1-bIN9YiWn3lZZMjdAs21TYfcWkf8=",
-      "dev": true,
-      "requires": {
-        "circular-json": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
-        "del": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-        "write": "https://registry.npmjs.org/write/-/write-0.2.1.tgz"
-      }
+      "dev": true
     },
     "flatten": {
       "version": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
@@ -13200,17 +12108,11 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.5.tgz",
       "integrity": "sha512-lMhwQTryFbG+wYsAIEKC1Kf5IGDlVNnONRogIBllh7LLoV7pNIxW0z9fhjRar9NBql+hd2Y49KboVVNxf6GEfg==",
-      "requires": {
-        "debug": "2.6.9"
-      },
       "dependencies": {
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="
         },
         "ms": {
           "version": "2.0.0",
@@ -13227,10 +12129,7 @@
     "for-own": {
       "version": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
       "integrity": "sha1-AUm0GjkIjHUV9R6+HBOG1F+TUHI=",
-      "dev": true,
-      "requires": {
-        "for-in": "https://registry.npmjs.org/for-in/-/for-in-0.1.6.tgz"
-      }
+      "dev": true
     },
     "foreach": {
       "version": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
@@ -13245,12 +12144,7 @@
     "form-data": {
       "version": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
       "integrity": "sha1-icNTQAi5fq2ky7FX1Y9vXfAl6uQ=",
-      "dev": true,
-      "requires": {
-        "asynckit": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-        "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz"
-      }
+      "dev": true
     },
     "forwarded": {
       "version": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
@@ -13265,14 +12159,7 @@
     "fs-extra": {
       "version": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
       "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-        "jsonfile": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-        "klaw": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
-        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz"
-      }
+      "dev": true
     },
     "fs.realpath": {
       "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -13282,217 +12169,137 @@
     "fsevents": {
       "version": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.14.tgz",
       "integrity": "sha1-VY6Mw4ZD2O9A/kUVhIbQ0ldY7uQ=",
-      "dev": true,
       "optional": true,
-      "requires": {
-        "nan": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz",
-        "node-pre-gyp": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.29.tgz"
-      },
       "dependencies": {
         "abbrev": {
           "version": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
           "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
-          "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
-          "dev": true
+          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
         },
         "ansi-styles": {
           "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true,
           "optional": true
         },
         "aproba": {
           "version": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz",
           "integrity": "sha1-JxNoB3XnYUyLoYbAZdTi5S0QcsA=",
-          "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
           "integrity": "sha1-gORw6VoIR5T+GJkmLFZnxuiN4bM=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "delegates": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz"
-          }
+          "optional": true
         },
         "asn1": {
           "version": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
           "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-          "dev": true,
           "optional": true
         },
         "assert-plus": {
           "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
           "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-          "dev": true,
           "optional": true
         },
         "async": {
           "version": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true,
           "optional": true
         },
         "aws-sign2": {
           "version": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
           "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-          "dev": true,
           "optional": true
         },
         "aws4": {
           "version": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz",
           "integrity": "sha1-/efVKSRm0jDl7g9OA42d+qsI/GE=",
-          "dev": true,
           "optional": true
         },
         "balanced-match": {
           "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-          "dev": true
+          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
         },
         "bl": {
           "version": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
           "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
-          "dev": true,
           "optional": true,
-          "requires": {
-            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
-          },
           "dependencies": {
             "readable-stream": {
               "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
               "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-              }
+              "optional": true
             }
           }
         },
         "block-stream": {
           "version": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-          "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-          "dev": true,
-          "requires": {
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-          }
+          "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo="
         },
         "boom": {
           "version": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-          "dev": true,
-          "requires": {
-            "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-          }
+          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8="
         },
         "brace-expansion": {
           "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.5.tgz",
-          "integrity": "sha1-9bStV04st8zB64Pm/nm47K33pSY=",
-          "dev": true,
-          "requires": {
-            "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-            "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-          }
+          "integrity": "sha1-9bStV04st8zB64Pm/nm47K33pSY="
         },
         "buffer-shims": {
           "version": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-          "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
-          "dev": true
+          "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
         },
         "caseless": {
           "version": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
           "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
-          "dev": true,
           "optional": true
         },
         "chalk": {
           "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-            "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-          }
+          "optional": true
         },
         "code-point-at": {
           "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
-          "integrity": "sha1-9psZLT99keOC5Lcb3bd4eGGasMY=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-          }
+          "integrity": "sha1-9psZLT99keOC5Lcb3bd4eGGasMY="
         },
         "combined-stream": {
           "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-          "dev": true,
-          "requires": {
-            "delayed-stream": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-          }
+          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk="
         },
         "commander": {
           "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "graceful-readlink": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-          }
+          "optional": true
         },
         "concat-map": {
           "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "console-control-strings": {
           "version": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
         },
         "core-util-is": {
           "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-          "dev": true
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
         "cryptiles": {
           "version": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
           "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-          }
+          "optional": true
         },
         "dashdash": {
           "version": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
           "integrity": "sha1-KeSGxUGL8PNWA0qZPVFoajPoQUE=",
-          "dev": true,
           "optional": true,
-          "requires": {
-            "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-          },
           "dependencies": {
             "assert-plus": {
               "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
               "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-              "dev": true,
               "optional": true
             }
           }
@@ -13500,725 +12307,429 @@
         "debug": {
           "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-          }
+          "optional": true
         },
         "deep-extend": {
           "version": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
           "integrity": "sha1-7+QRPQgIX05vlod1mBD4B0aeIlM=",
-          "dev": true,
           "optional": true
         },
         "delayed-stream": {
           "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-          "dev": true
+          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
         },
         "delegates": {
           "version": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-          "dev": true,
           "optional": true
         },
         "ecc-jsbn": {
           "version": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
           "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
-          }
+          "optional": true
         },
         "escape-string-regexp": {
           "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
           "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true,
           "optional": true
         },
         "extend": {
           "version": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
           "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
-          "dev": true,
           "optional": true
         },
         "extsprintf": {
           "version": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
-          "dev": true
+          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
         },
         "forever-agent": {
           "version": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
           "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-          "dev": true,
           "optional": true
         },
         "form-data": {
           "version": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
           "integrity": "sha1-BaxrwiIntD5EYfSIFhVUaZ1Pi14=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-            "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-            "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz"
-          }
+          "optional": true
         },
         "fs.realpath": {
           "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-          "dev": true
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "fstream": {
           "version": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
-          "integrity": "sha1-YE6Kkv4m/9n2+uMDmdSYThqyKCI=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-            "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.3.tgz"
-          }
+          "integrity": "sha1-YE6Kkv4m/9n2+uMDmdSYThqyKCI="
         },
         "fstream-ignore": {
           "version": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
           "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "fstream": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz"
-          }
+          "optional": true
         },
         "gauge": {
           "version": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz",
           "integrity": "sha1-01MBrRjpaQK0dR3LvkD0IYuUKkY=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aproba": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz",
-            "console-control-strings": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-            "has-color": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-            "has-unicode": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-            "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-            "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.0.tgz",
-            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
-            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "wide-align": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz"
-          }
+          "optional": true
         },
         "generate-function": {
           "version": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
           "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-          "dev": true,
           "optional": true
         },
         "generate-object-property": {
           "version": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
           "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "is-property": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
-          }
+          "optional": true
         },
         "getpass": {
           "version": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
           "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
-          "dev": true,
           "optional": true,
-          "requires": {
-            "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-          },
           "dependencies": {
             "assert-plus": {
               "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
               "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-              "dev": true,
               "optional": true
             }
           }
         },
         "glob": {
           "version": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
-          "integrity": "sha1-tCAqaQmbu00pKnwblbZoK2fr3JU=",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
-            "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-          }
+          "integrity": "sha1-tCAqaQmbu00pKnwblbZoK2fr3JU="
         },
         "graceful-fs": {
           "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz",
-          "integrity": "sha1-7widKIDwM7ARgjzlyPrnmNp3Xb0=",
-          "dev": true
+          "integrity": "sha1-7widKIDwM7ARgjzlyPrnmNp3Xb0="
         },
         "graceful-readlink": {
           "version": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
           "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-          "dev": true,
           "optional": true
         },
         "har-validator": {
           "version": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
           "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-            "commander": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-            "is-my-json-valid": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
-            "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
-          }
+          "optional": true
         },
         "has-ansi": {
           "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
           "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-          }
+          "optional": true
         },
         "has-color": {
           "version": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
           "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
-          "dev": true,
           "optional": true
         },
         "has-unicode": {
           "version": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
           "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-          "dev": true,
           "optional": true
         },
         "hawk": {
           "version": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
           "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-            "cryptiles": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-            "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-            "sntp": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-          }
+          "optional": true
         },
         "hoek": {
           "version": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-          "dev": true
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
         },
         "http-signature": {
           "version": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
           "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-            "jsprim": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz",
-            "sshpk": "https://registry.npmjs.org/sshpk/-/sshpk-1.8.3.tgz"
-          }
+          "optional": true
         },
         "inflight": {
           "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
-          "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
-          "dev": true,
-          "requires": {
-            "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-            "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-          }
+          "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo="
         },
         "inherits": {
           "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
-          "dev": true
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
         },
         "ini": {
           "version": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
           "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
-          "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-          }
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs="
         },
         "is-my-json-valid": {
           "version": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
           "integrity": "sha1-1Vd4qC/rawlj/0vhEdXRaE6JBwc=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "generate-function": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-            "generate-object-property": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-            "jsonpointer": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
-            "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-          }
+          "optional": true
         },
         "is-property": {
           "version": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
           "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-          "dev": true,
           "optional": true
         },
         "is-typedarray": {
           "version": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
           "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-          "dev": true,
           "optional": true
         },
         "isarray": {
           "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "isstream": {
           "version": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
           "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-          "dev": true,
           "optional": true
         },
         "jodid25519": {
           "version": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
           "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
-          }
+          "optional": true
         },
         "jsbn": {
           "version": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
           "integrity": "sha1-ZQmH2g3XT06/WhE3eiqi0nPpff0=",
-          "dev": true,
           "optional": true
         },
         "json-schema": {
           "version": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
           "integrity": "sha1-UDVPGfYDkXxpX3C4Wvp3w7DyNQY=",
-          "dev": true,
           "optional": true
         },
         "json-stringify-safe": {
           "version": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
           "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-          "dev": true,
           "optional": true
         },
         "jsonpointer": {
           "version": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
           "integrity": "sha1-OvHdIP6FRjkQ1GmjheMwF9KgMNk=",
-          "dev": true,
           "optional": true
         },
         "jsprim": {
           "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz",
           "integrity": "sha1-zi4b74NSBLTzCZkoxgL4tq5hVlA=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-            "json-schema": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
-            "verror": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
-          }
+          "optional": true
         },
         "mime-db": {
           "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
-          "integrity": "sha1-oxtAcK2uon1zLqMzdApk0OyaZlk=",
-          "dev": true
+          "integrity": "sha1-oxtAcK2uon1zLqMzdApk0OyaZlk="
         },
         "mime-types": {
           "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
-          "integrity": "sha1-wlnEcb2oCKhdbNGTtDCl+uRHOzw=",
-          "dev": true,
-          "requires": {
-            "mime-db": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
-          }
+          "integrity": "sha1-wlnEcb2oCKhdbNGTtDCl+uRHOzw="
         },
         "minimatch": {
           "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
-          "integrity": "sha1-DzmKcwDqRB6cNIyD2Yq4ydv5xAo=",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.5.tgz"
-          }
+          "integrity": "sha1-DzmKcwDqRB6cNIyD2Yq4ydv5xAo="
         },
         "minimist": {
           "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "mkdirp": {
           "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true,
-          "requires": {
-            "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-          }
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM="
         },
         "ms": {
           "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
           "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true,
           "optional": true
         },
         "node-pre-gyp": {
           "version": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.29.tgz",
           "integrity": "sha1-sL0TY1uvfRvnriM8FvvPMwms03w=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-            "nopt": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-            "npmlog": "https://registry.npmjs.org/npmlog/-/npmlog-3.1.2.tgz",
-            "rc": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
-            "request": "https://registry.npmjs.org/request/-/request-2.73.0.tgz",
-            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.3.tgz",
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.2.0.tgz",
-            "tar": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-            "tar-pack": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.4.tgz"
-          }
+          "optional": true
         },
         "node-uuid": {
           "version": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
           "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8=",
-          "dev": true,
           "optional": true
         },
         "nopt": {
           "version": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
-          }
+          "optional": true
         },
         "npmlog": {
           "version": "https://registry.npmjs.org/npmlog/-/npmlog-3.1.2.tgz",
           "integrity": "sha1-LUb6h0M3r5SYovErtD2NC+SjaHM=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
-            "console-control-strings": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-            "gauge": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz",
-            "set-blocking": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
-          }
+          "optional": true
         },
         "number-is-nan": {
           "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-          "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es=",
-          "dev": true
+          "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
         },
         "oauth-sign": {
           "version": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
           "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-          "dev": true,
           "optional": true
         },
         "object-assign": {
           "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
           "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
-          "dev": true,
           "optional": true
         },
         "once": {
           "version": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-          "dev": true,
-          "requires": {
-            "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-          }
+          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA="
         },
         "path-is-absolute": {
           "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-          "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
-          "dev": true
+          "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI="
         },
         "pinkie": {
           "version": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
           "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-          "dev": true,
           "optional": true
         },
         "pinkie-promise": {
           "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
           "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "pinkie": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-          }
+          "optional": true
         },
         "process-nextick-args": {
           "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-          "dev": true
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
         },
         "qs": {
           "version": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz",
           "integrity": "sha1-O3hIwDwt7OaalSKw+ujEEm10Xzs=",
-          "dev": true,
           "optional": true
         },
         "rc": {
           "version": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
           "integrity": "sha1-Q2UbdrauU7XIAvEVH6P8OwWZack=",
-          "dev": true,
           "optional": true,
-          "requires": {
-            "deep-extend": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
-            "ini": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-            "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-            "strip-json-comments": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
-          },
           "dependencies": {
             "minimist": {
               "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-              "dev": true,
               "optional": true
             }
           }
         },
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz",
-          "integrity": "sha1-cLl5HG/LhIDbRL0VWg9rtY8XJGg=",
-          "dev": true,
-          "requires": {
-            "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-          }
+          "integrity": "sha1-cLl5HG/LhIDbRL0VWg9rtY8XJGg="
         },
         "request": {
           "version": "https://registry.npmjs.org/request/-/request-2.73.0.tgz",
           "integrity": "sha1-X3ip/eQ3CryP9kedeoSnGhS4eKI=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aws-sign2": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-            "aws4": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz",
-            "bl": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
-            "caseless": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-            "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-            "extend": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-            "forever-agent": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-            "form-data": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
-            "har-validator": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-            "hawk": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-            "http-signature": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-            "is-typedarray": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-            "isstream": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-            "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-            "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
-            "node-uuid": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-            "oauth-sign": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-            "qs": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz",
-            "stringstream": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-            "tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
-            "tunnel-agent": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
-          }
+          "optional": true
         },
         "rimraf": {
           "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.3.tgz",
-          "integrity": "sha1-bl792kqi8DQX9rKldK7Cn0tlJwU=",
-          "dev": true,
-          "requires": {
-            "glob": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz"
-          }
+          "integrity": "sha1-bl792kqi8DQX9rKldK7Cn0tlJwU="
         },
         "semver": {
           "version": "https://registry.npmjs.org/semver/-/semver-5.2.0.tgz",
           "integrity": "sha1-KBmVuAwUSCCUFd28TPUMJpzvVcU=",
-          "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-          "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.0.tgz",
           "integrity": "sha1-PAVDtl17T7xgts2UWT2b9DZzm+g=",
-          "dev": true,
           "optional": true
         },
         "sntp": {
           "version": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
           "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-          }
+          "optional": true
         },
         "sshpk": {
           "version": "https://registry.npmjs.org/sshpk/-/sshpk-1.8.3.tgz",
           "integrity": "sha1-iQzJ1hTcUpLlyxpUOwPJq6pcN04=",
-          "dev": true,
           "optional": true,
-          "requires": {
-            "asn1": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-            "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-            "dashdash": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
-            "ecc-jsbn": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-            "getpass": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
-            "jodid25519": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-            "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-            "tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
-          },
           "dependencies": {
             "assert-plus": {
               "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
               "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-              "dev": true,
               "optional": true
             }
           }
         },
         "string_decoder": {
           "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         },
         "string-width": {
           "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
-          "integrity": "sha1-ySEptvHX9SrPmvQkom44ZKBc6wo=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
-            "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
-          }
+          "integrity": "sha1-ySEptvHX9SrPmvQkom44ZKBc6wo="
         },
         "stringstream": {
           "version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
           "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-          "dev": true,
           "optional": true
         },
         "strip-ansi": {
           "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-          }
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
         },
         "strip-json-comments": {
           "version": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
           "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
-          "dev": true,
           "optional": true
         },
         "supports-color": {
           "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true,
           "optional": true
         },
         "tar": {
           "version": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-          "dev": true,
-          "requires": {
-            "block-stream": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-            "fstream": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-          }
+          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE="
         },
         "tar-pack": {
           "version": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.4.tgz",
           "integrity": "sha1-vIz5oi9YMnOfEvORDaweuXtJcIw=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-            "fstream": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
-            "fstream-ignore": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-            "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz",
-            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.3.tgz",
-            "tar": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-            "uid-number": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
-          }
+          "optional": true
         },
         "tough-cookie": {
           "version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
           "integrity": "sha1-yDoYMPTl7wuT7yo0iOck+N4Basc=",
-          "dev": true,
           "optional": true
         },
         "tunnel-agent": {
           "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
           "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-          "dev": true,
           "optional": true
         },
         "tweetnacl": {
           "version": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
           "integrity": "sha1-1ii1bzvMPVrnS6nUwacE3vWrS1Y=",
-          "dev": true,
           "optional": true
         },
         "uid-number": {
           "version": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
           "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
-          "dev": true,
           "optional": true
         },
         "util-deprecate": {
           "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-          "dev": true
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "verror": {
           "version": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
           "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
-          }
+          "optional": true
         },
         "wide-align": {
           "version": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
           "integrity": "sha1-QO3egCpx/qHwcNo+YtzaLnrdlq0=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz"
-          }
+          "optional": true
         },
         "wrappy": {
           "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "xtend": {
           "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
           "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-          "dev": true,
           "optional": true
         }
       }
@@ -14236,10 +12747,7 @@
     "generate-object-property": {
       "version": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true,
-      "requires": {
-        "is-property": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
-      }
+      "dev": true
     },
     "get-caller-file": {
       "version": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
@@ -14250,9 +12758,6 @@
       "version": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
       "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
       "dev": true,
-      "requires": {
-        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-      },
       "dependencies": {
         "assert-plus": {
           "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -14264,32 +12769,17 @@
     "glob": {
       "version": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
       "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-      "dev": true,
-      "requires": {
-        "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-        "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-      }
+      "dev": true
     },
     "glob-base": {
       "version": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "dev": true,
-      "requires": {
-        "glob-parent": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-        "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
-      }
+      "dev": true
     },
     "glob-parent": {
       "version": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-      "dev": true,
-      "requires": {
-        "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
-      }
+      "dev": true
     },
     "globals": {
       "version": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz",
@@ -14299,15 +12789,7 @@
     "globby": {
       "version": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-      "dev": true,
-      "requires": {
-        "array-union": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-        "arrify": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-        "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
-      }
+      "dev": true
     },
     "graceful-fs": {
       "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
@@ -14327,29 +12809,17 @@
     "gzip-size": {
       "version": "https://registry.npmjs.org/gzip-size/-/gzip-size-3.0.0.tgz",
       "integrity": "sha1-VGGI6b3DN/Zzdy+BZgRks4nc5SA=",
-      "dev": true,
-      "requires": {
-        "duplexer": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
-      }
+      "dev": true
     },
     "handlebars": {
       "version": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz",
       "integrity": "sha1-LORISFBTf5yXqAJtU5m5NcTtTtc=",
       "dev": true,
-      "requires": {
-        "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-        "optimist": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-        "uglify-js": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.4.tgz"
-      },
       "dependencies": {
         "source-map": {
           "version": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true,
-          "requires": {
-            "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
-          }
+          "dev": true
         }
       }
     },
@@ -14357,38 +12827,23 @@
       "version": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
       "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
       "dev": true,
-      "requires": {
-        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-        "commander": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-        "is-my-json-valid": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
-        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
-      },
       "dependencies": {
         "commander": {
           "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-          "dev": true,
-          "requires": {
-            "graceful-readlink": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-          }
+          "dev": true
         }
       }
     },
     "has": {
       "version": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
-      "dev": true,
-      "requires": {
-        "function-bind": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
-      }
+      "dev": true
     },
     "has-ansi": {
       "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-      }
+      "dev": true
     },
     "has-flag": {
       "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
@@ -14398,13 +12853,7 @@
     "hawk": {
       "version": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-      "dev": true,
-      "requires": {
-        "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-        "cryptiles": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-        "sntp": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-      }
+      "dev": true
     },
     "he": {
       "version": "https://registry.npmjs.org/he/-/he-1.1.0.tgz",
@@ -14419,11 +12868,7 @@
     "home-or-tmp": {
       "version": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-      "dev": true,
-      "requires": {
-        "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-        "os-tmpdir": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
-      }
+      "dev": true
     },
     "hosted-git-info": {
       "version": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
@@ -14438,10 +12883,7 @@
     "html-encoding-sniffer": {
       "version": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz",
       "integrity": "sha1-eb96eF6klf5mFl5zQVPzY/9UN9o=",
-      "dev": true,
-      "requires": {
-        "whatwg-encoding": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.1.tgz"
-      }
+      "dev": true
     },
     "html-entities": {
       "version": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.0.tgz",
@@ -14452,78 +12894,38 @@
       "version": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.2.3.tgz",
       "integrity": "sha1-0v9TbiTZVybDMkk9j3fYTb7YU3I=",
       "dev": true,
-      "requires": {
-        "camel-case": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
-        "clean-css": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.21.tgz",
-        "commander": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-        "he": "https://registry.npmjs.org/he/-/he-1.1.0.tgz",
-        "ncname": "https://registry.npmjs.org/ncname/-/ncname-1.0.0.tgz",
-        "param-case": "https://registry.npmjs.org/param-case/-/param-case-2.1.0.tgz",
-        "relateurl": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
-        "uglify-js": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.4.tgz"
-      },
       "dependencies": {
         "commander": {
           "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-          "dev": true,
-          "requires": {
-            "graceful-readlink": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-          }
+          "dev": true
         }
       }
     },
     "html-webpack-plugin": {
       "version": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-2.24.0.tgz",
       "integrity": "sha1-U2l86nmp880fjCOaxx+UnVZzyss=",
-      "dev": true,
-      "requires": {
-        "bluebird": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.6.tgz",
-        "html-minifier": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.2.3.tgz",
-        "loader-utils": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.16.tgz",
-        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-        "pretty-error": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.0.2.tgz",
-        "toposort": "https://registry.npmjs.org/toposort/-/toposort-1.0.0.tgz"
-      }
+      "dev": true
     },
     "http-browserify": {
       "version": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
       "integrity": "sha1-M3la3nLfiKz7/TZ3PO/tp2RzWyA=",
-      "dev": true,
-      "requires": {
-        "Base64": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
-        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-      }
+      "dev": true
     },
     "http-errors": {
       "version": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
       "integrity": "sha1-eIwNLB3iyBuebowBhDtrl+uSB1A=",
-      "dev": true,
-      "requires": {
-        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-        "setprototypeof": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz",
-        "statuses": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
-      }
+      "dev": true
     },
     "http-proxy": {
       "version": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.15.2.tgz",
       "integrity": "sha1-ZC/cr/5S00SNK9o7AHnpQJBk2jE=",
-      "dev": true,
-      "requires": {
-        "eventemitter3": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
-        "requires-port": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
-      }
+      "dev": true
     },
     "http-proxy-middleware": {
       "version": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.2.tgz",
       "integrity": "sha1-Vy1Rem0vsQY6Rp3ilO7ZYGY1IAc=",
       "dev": true,
-      "requires": {
-        "http-proxy": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.15.2.tgz",
-        "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-        "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz"
-      },
       "dependencies": {
         "is-extglob": {
           "version": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.0.tgz",
@@ -14533,22 +12935,14 @@
         "is-glob": {
           "version": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.0.tgz"
-          }
+          "dev": true
         }
       }
     },
     "http-signature": {
       "version": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-        "jsprim": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
-        "sshpk": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz"
-      }
+      "dev": true
     },
     "https-browserify": {
       "version": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz",
@@ -14592,11 +12986,7 @@
     "inflight": {
       "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
-      "requires": {
-        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-        "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-      }
+      "dev": true
     },
     "inherits": {
       "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
@@ -14606,22 +12996,7 @@
     "inquirer": {
       "version": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
       "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
-      "dev": true,
-      "requires": {
-        "ansi-escapes": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-        "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-        "cli-cursor": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-        "cli-width": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-        "figures": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-        "readline2": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-        "run-async": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-        "rx-lite": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-        "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-      }
+      "dev": true
     },
     "interpret": {
       "version": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz",
@@ -14631,10 +13006,7 @@
     "invariant": {
       "version": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
       "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
-      "dev": true,
-      "requires": {
-        "loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz"
-      }
+      "dev": true
     },
     "invert-kv": {
       "version": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
@@ -14659,18 +13031,12 @@
     "is-arrow-function": {
       "version": "https://registry.npmjs.org/is-arrow-function/-/is-arrow-function-2.0.3.tgz",
       "integrity": "sha1-Kb4sLY2UUIUri7r7Y1unuNjofsI=",
-      "dev": true,
-      "requires": {
-        "is-callable": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz"
-      }
+      "dev": true
     },
     "is-binary-path": {
       "version": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-      "dev": true,
-      "requires": {
-        "binary-extensions": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.7.0.tgz"
-      }
+      "dev": true
     },
     "is-boolean-object": {
       "version": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.0.0.tgz",
@@ -14685,10 +13051,7 @@
     "is-builtin-module": {
       "version": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "dev": true,
-      "requires": {
-        "builtin-modules": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
-      }
+      "dev": true
     },
     "is-callable": {
       "version": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
@@ -14698,10 +13061,7 @@
     "is-ci": {
       "version": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
       "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
-      "dev": true,
-      "requires": {
-        "ci-info": "https://registry.npmjs.org/ci-info/-/ci-info-1.0.0.tgz"
-      }
+      "dev": true
     },
     "is-date-object": {
       "version": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
@@ -14716,28 +13076,12 @@
     "is-equal": {
       "version": "https://registry.npmjs.org/is-equal/-/is-equal-1.5.3.tgz",
       "integrity": "sha1-Bbf6OhEiy8ccHvQc4BQtVTIBOyk=",
-      "dev": true,
-      "requires": {
-        "has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
-        "is-arrow-function": "https://registry.npmjs.org/is-arrow-function/-/is-arrow-function-2.0.3.tgz",
-        "is-boolean-object": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.0.0.tgz",
-        "is-callable": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-        "is-date-object": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-        "is-generator-function": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.3.tgz",
-        "is-number-object": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.3.tgz",
-        "is-regex": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.3.tgz",
-        "is-string": "https://registry.npmjs.org/is-string/-/is-string-1.0.4.tgz",
-        "is-symbol": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-        "object.entries": "https://registry.npmjs.org/object.entries/-/object.entries-1.0.3.tgz"
-      }
+      "dev": true
     },
     "is-equal-shallow": {
       "version": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-      "dev": true,
-      "requires": {
-        "is-primitive": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
-      }
+      "dev": true
     },
     "is-extendable": {
       "version": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -14752,18 +13096,12 @@
     "is-finite": {
       "version": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true,
-      "requires": {
-        "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
-      }
+      "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "dev": true,
-      "requires": {
-        "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
-      }
+      "dev": true
     },
     "is-generator-function": {
       "version": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.3.tgz",
@@ -14773,29 +13111,17 @@
     "is-glob": {
       "version": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-      "dev": true,
-      "requires": {
-        "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
-      }
+      "dev": true
     },
     "is-my-json-valid": {
       "version": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
       "integrity": "sha1-k27do8o8IR/ZjzstPgjaQ/eykVs=",
-      "dev": true,
-      "requires": {
-        "generate-function": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-        "generate-object-property": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-        "jsonpointer": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.0.tgz",
-        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-      }
+      "dev": true
     },
     "is-number": {
       "version": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-      "dev": true,
-      "requires": {
-        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz"
-      }
+      "dev": true
     },
     "is-number-object": {
       "version": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.3.tgz",
@@ -14810,18 +13136,12 @@
     "is-path-in-cwd": {
       "version": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-      "dev": true,
-      "requires": {
-        "is-path-inside": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz"
-      }
+      "dev": true
     },
     "is-path-inside": {
       "version": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
       "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
-      "dev": true,
-      "requires": {
-        "path-is-inside": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz"
-      }
+      "dev": true
     },
     "is-plain-obj": {
       "version": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
@@ -14851,10 +13171,7 @@
     "is-resolvable": {
       "version": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
       "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-      "dev": true,
-      "requires": {
-        "tryit": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz"
-      }
+      "dev": true
     },
     "is-stream": {
       "version": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -14868,10 +13185,7 @@
     "is-svg": {
       "version": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
       "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
-      "dev": true,
-      "requires": {
-        "html-comment-regex": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.1.tgz"
-      }
+      "dev": true
     },
     "is-symbol": {
       "version": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
@@ -14901,18 +13215,11 @@
     "isobject": {
       "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
       "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-      "dev": true,
-      "requires": {
-        "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-      }
+      "dev": true
     },
     "isomorphic-fetch": {
       "version": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "requires": {
-        "node-fetch": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
-        "whatwg-fetch": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-1.0.0.tgz"
-      }
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk="
     },
     "isstream": {
       "version": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -14923,55 +13230,18 @@
       "version": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
       "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
       "dev": true,
-      "requires": {
-        "abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-        "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-        "escodegen": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
-        "esprima": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-        "glob": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-        "handlebars": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz",
-        "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
-        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-        "nopt": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-        "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-        "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-        "which": "https://registry.npmjs.org/which/-/which-1.2.12.tgz",
-        "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
-      },
       "dependencies": {
         "glob": {
           "version": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true,
-          "requires": {
-            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-          }
+          "dev": true
         }
       }
     },
     "istanbul-api": {
       "version": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.0.0-aplha.10.tgz",
       "integrity": "sha1-kC7fXPVATg66fgDvRkCEiKDT4zc=",
-      "dev": true,
-      "requires": {
-        "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-        "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-        "fileset": "https://registry.npmjs.org/fileset/-/fileset-0.2.1.tgz",
-        "istanbul-lib-coverage": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.0.0.tgz",
-        "istanbul-lib-hook": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.0-alpha.4.tgz",
-        "istanbul-lib-instrument": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.3.0.tgz",
-        "istanbul-lib-report": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.0.0-alpha.3.tgz",
-        "istanbul-lib-source-maps": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.1.0.tgz",
-        "istanbul-reports": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.0.0.tgz",
-        "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
-        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
-      }
+      "dev": true
     },
     "istanbul-lib-coverage": {
       "version": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.0.0.tgz",
@@ -14981,72 +13251,37 @@
     "istanbul-lib-hook": {
       "version": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.0-alpha.4.tgz",
       "integrity": "sha1-jFu59vvYUm4K5s9jmvKCZpBrk48=",
-      "dev": true,
-      "requires": {
-        "append-transform": "https://registry.npmjs.org/append-transform/-/append-transform-0.3.0.tgz"
-      }
+      "dev": true
     },
     "istanbul-lib-instrument": {
       "version": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.3.0.tgz",
       "integrity": "sha1-GfCpczl0VJibmDMDMwY6W1bfDlg=",
-      "dev": true,
-      "requires": {
-        "babel-generator": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.19.0.tgz",
-        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
-        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.19.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-        "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
-        "istanbul-lib-coverage": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.0.0.tgz",
-        "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
-      }
+      "dev": true
     },
     "istanbul-lib-report": {
       "version": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.0.0-alpha.3.tgz",
       "integrity": "sha1-MtX27H8zyjpgIgnieLLm/xQ0mK8=",
-      "dev": true,
-      "requires": {
-        "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-        "istanbul-lib-coverage": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.0.0.tgz",
-        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-        "path-parse": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
-        "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
-      }
+      "dev": true
     },
     "istanbul-lib-source-maps": {
       "version": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.1.0.tgz",
       "integrity": "sha1-nUKSGPNbgjVg6jAKlv8MO72reF8=",
-      "dev": true,
-      "requires": {
-        "istanbul-lib-coverage": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.0.0.tgz",
-        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
-        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
-      }
+      "dev": true
     },
     "istanbul-reports": {
       "version": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.0.0.tgz",
       "integrity": "sha1-JLTrKx0p1Q8QOzab1CL25kCqB3c=",
-      "dev": true,
-      "requires": {
-        "handlebars": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz"
-      }
+      "dev": true
     },
     "jasmine-check": {
       "version": "https://registry.npmjs.org/jasmine-check/-/jasmine-check-0.1.5.tgz",
       "integrity": "sha1-261+7FYmHEs9F1raVf5ZsJrJ5BU=",
-      "dev": true,
-      "requires": {
-        "testcheck": "https://registry.npmjs.org/testcheck/-/testcheck-0.1.4.tgz"
-      }
+      "dev": true
     },
     "jest": {
       "version": "https://registry.npmjs.org/jest/-/jest-16.0.2.tgz",
       "integrity": "sha1-Si9/NSdGUWiguv4MPVUFUYglPzo=",
       "dev": true,
-      "requires": {
-        "jest-cli": "https://registry.npmjs.org/jest-cli/-/jest-cli-16.0.2.tgz"
-      },
       "dependencies": {
         "callsites": {
           "version": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
@@ -15056,47 +13291,12 @@
         "cliui": {
           "version": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "dev": true,
-          "requires": {
-            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "wrap-ansi": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz"
-          }
+          "dev": true
         },
         "jest-cli": {
           "version": "https://registry.npmjs.org/jest-cli/-/jest-cli-16.0.2.tgz",
           "integrity": "sha1-1Dmyiv+nGJqj0EbSr5Mffrua9p0=",
-          "dev": true,
-          "requires": {
-            "ansi-escapes": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-            "callsites": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-            "is-ci": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
-            "istanbul-api": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.0.0-aplha.10.tgz",
-            "istanbul-lib-coverage": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.0.0.tgz",
-            "istanbul-lib-instrument": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.3.0.tgz",
-            "jest-changed-files": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-16.0.0.tgz",
-            "jest-config": "https://registry.npmjs.org/jest-config/-/jest-config-16.0.2.tgz",
-            "jest-environment-jsdom": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-16.0.2.tgz",
-            "jest-file-exists": "https://registry.npmjs.org/jest-file-exists/-/jest-file-exists-15.0.0.tgz",
-            "jest-haste-map": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-16.0.2.tgz",
-            "jest-jasmine2": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-16.0.2.tgz",
-            "jest-mock": "https://registry.npmjs.org/jest-mock/-/jest-mock-16.0.2.tgz",
-            "jest-resolve": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-16.0.2.tgz",
-            "jest-resolve-dependencies": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-16.0.2.tgz",
-            "jest-runtime": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-16.0.2.tgz",
-            "jest-snapshot": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-16.0.2.tgz",
-            "jest-util": "https://registry.npmjs.org/jest-util/-/jest-util-16.0.2.tgz",
-            "json-stable-stringify": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-            "node-notifier": "https://registry.npmjs.org/node-notifier/-/node-notifier-4.6.1.tgz",
-            "sane": "https://registry.npmjs.org/sane/-/sane-1.4.1.tgz",
-            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "throat": "https://registry.npmjs.org/throat/-/throat-3.0.0.tgz",
-            "which": "https://registry.npmjs.org/which/-/which-1.2.12.tgz",
-            "worker-farm": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.3.1.tgz",
-            "yargs": "https://registry.npmjs.org/yargs/-/yargs-5.0.0.tgz"
-          }
+          "dev": true
         },
         "window-size": {
           "version": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
@@ -15106,23 +13306,7 @@
         "yargs": {
           "version": "https://registry.npmjs.org/yargs/-/yargs-5.0.0.tgz",
           "integrity": "sha1-M1UUSXfQV1fbuG1uOOwFYSOzpm4=",
-          "dev": true,
-          "requires": {
-            "cliui": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-            "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-            "get-caller-file": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-            "lodash.assign": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-            "os-locale": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-            "read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-            "require-directory": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-            "require-main-filename": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-            "set-blocking": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-            "which-module": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-            "window-size": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-            "y18n": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-            "yargs-parser": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-3.2.0.tgz"
-          }
+          "dev": true
         }
       }
     },
@@ -15134,48 +13318,22 @@
     "jest-config": {
       "version": "https://registry.npmjs.org/jest-config/-/jest-config-16.0.2.tgz",
       "integrity": "sha1-joKpwIhG8j3H/UK1wKH1lsOFdyo=",
-      "dev": true,
-      "requires": {
-        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-        "istanbul": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
-        "jest-environment-jsdom": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-16.0.2.tgz",
-        "jest-environment-node": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-16.0.2.tgz",
-        "jest-jasmine2": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-16.0.2.tgz",
-        "jest-mock": "https://registry.npmjs.org/jest-mock/-/jest-mock-16.0.2.tgz",
-        "jest-resolve": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-16.0.2.tgz",
-        "jest-util": "https://registry.npmjs.org/jest-util/-/jest-util-16.0.2.tgz",
-        "json-stable-stringify": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
-      }
+      "dev": true
     },
     "jest-diff": {
       "version": "https://registry.npmjs.org/jest-diff/-/jest-diff-16.0.0.tgz",
       "integrity": "sha1-Sl0TseNsW4Ag1dnmljnkhqZ1zhQ=",
-      "dev": true,
-      "requires": {
-        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-        "diff": "https://registry.npmjs.org/diff/-/diff-3.1.0.tgz",
-        "jest-matcher-utils": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-16.0.0.tgz",
-        "pretty-format": "https://registry.npmjs.org/pretty-format/-/pretty-format-4.2.3.tgz"
-      }
+      "dev": true
     },
     "jest-environment-jsdom": {
       "version": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-16.0.2.tgz",
       "integrity": "sha1-VI2IO2j47QvWRm2HA5hilnJMHvc=",
-      "dev": true,
-      "requires": {
-        "jest-mock": "https://registry.npmjs.org/jest-mock/-/jest-mock-16.0.2.tgz",
-        "jest-util": "https://registry.npmjs.org/jest-util/-/jest-util-16.0.2.tgz",
-        "jsdom": "https://registry.npmjs.org/jsdom/-/jsdom-9.8.3.tgz"
-      }
+      "dev": true
     },
     "jest-environment-node": {
       "version": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-16.0.2.tgz",
       "integrity": "sha1-63s6SpxjtyjOAjgo1LVmGq2Megg=",
-      "dev": true,
-      "requires": {
-        "jest-mock": "https://registry.npmjs.org/jest-mock/-/jest-mock-16.0.2.tgz",
-        "jest-util": "https://registry.npmjs.org/jest-util/-/jest-util-16.0.2.tgz"
-      }
+      "dev": true
     },
     "jest-file-exists": {
       "version": "https://registry.npmjs.org/jest-file-exists/-/jest-file-exists-15.0.0.tgz",
@@ -15185,44 +13343,22 @@
     "jest-haste-map": {
       "version": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-16.0.2.tgz",
       "integrity": "sha1-RWKRWyUXGuLQ11EYyZLw6XU2ou0=",
-      "dev": true,
-      "requires": {
-        "fb-watchman": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-1.9.0.tgz",
-        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-        "multimatch": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
-        "worker-farm": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.3.1.tgz"
-      }
+      "dev": true
     },
     "jest-jasmine2": {
       "version": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-16.0.2.tgz",
       "integrity": "sha1-yRrhcNEnquIhgNv+GB13ZVpdqMM=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-        "jasmine-check": "https://registry.npmjs.org/jasmine-check/-/jasmine-check-0.1.5.tgz",
-        "jest-matchers": "https://registry.npmjs.org/jest-matchers/-/jest-matchers-16.0.2.tgz",
-        "jest-snapshot": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-16.0.2.tgz",
-        "jest-util": "https://registry.npmjs.org/jest-util/-/jest-util-16.0.2.tgz"
-      }
+      "dev": true
     },
     "jest-matcher-utils": {
       "version": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-16.0.0.tgz",
       "integrity": "sha1-cFrz/4WUS+wcJbyBP0J6/4ZCsM0=",
-      "dev": true,
-      "requires": {
-        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-        "pretty-format": "https://registry.npmjs.org/pretty-format/-/pretty-format-4.2.3.tgz"
-      }
+      "dev": true
     },
     "jest-matchers": {
       "version": "https://registry.npmjs.org/jest-matchers/-/jest-matchers-16.0.2.tgz",
       "integrity": "sha1-wHjCjP4FubHylfmrJ7WZHxCVu78=",
-      "dev": true,
-      "requires": {
-        "jest-diff": "https://registry.npmjs.org/jest-diff/-/jest-diff-16.0.0.tgz",
-        "jest-matcher-utils": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-16.0.0.tgz",
-        "jest-util": "https://registry.npmjs.org/jest-util/-/jest-util-16.0.2.tgz"
-      }
+      "dev": true
     },
     "jest-mock": {
       "version": "https://registry.npmjs.org/jest-mock/-/jest-mock-16.0.2.tgz",
@@ -15232,54 +13368,22 @@
     "jest-resolve": {
       "version": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-16.0.2.tgz",
       "integrity": "sha1-RrkrnCpEqn3dmmtz3CNOlQPoxgk=",
-      "dev": true,
-      "requires": {
-        "browser-resolve": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
-        "jest-file-exists": "https://registry.npmjs.org/jest-file-exists/-/jest-file-exists-15.0.0.tgz",
-        "jest-haste-map": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-16.0.2.tgz",
-        "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
-      }
+      "dev": true
     },
     "jest-resolve-dependencies": {
       "version": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-16.0.2.tgz",
       "integrity": "sha1-sgQWbVAUFGnRBmfcIWI5wL6GVyk=",
-      "dev": true,
-      "requires": {
-        "jest-file-exists": "https://registry.npmjs.org/jest-file-exists/-/jest-file-exists-15.0.0.tgz",
-        "jest-resolve": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-16.0.2.tgz"
-      }
+      "dev": true
     },
     "jest-runtime": {
       "version": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-16.0.2.tgz",
       "integrity": "sha1-p0Ho1Vp7XwEbvheiLGc6g9J4pF0=",
       "dev": true,
-      "requires": {
-        "babel-core": "https://registry.npmjs.org/babel-core/-/babel-core-6.17.0.tgz",
-        "babel-jest": "https://registry.npmjs.org/babel-jest/-/babel-jest-16.0.0.tgz",
-        "babel-plugin-istanbul": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-2.0.3.tgz",
-        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-        "jest-config": "https://registry.npmjs.org/jest-config/-/jest-config-16.0.2.tgz",
-        "jest-file-exists": "https://registry.npmjs.org/jest-file-exists/-/jest-file-exists-15.0.0.tgz",
-        "jest-haste-map": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-16.0.2.tgz",
-        "jest-mock": "https://registry.npmjs.org/jest-mock/-/jest-mock-16.0.2.tgz",
-        "jest-resolve": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-16.0.2.tgz",
-        "jest-snapshot": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-16.0.2.tgz",
-        "jest-util": "https://registry.npmjs.org/jest-util/-/jest-util-16.0.2.tgz",
-        "json-stable-stringify": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-        "multimatch": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
-        "yargs": "https://registry.npmjs.org/yargs/-/yargs-5.0.0.tgz"
-      },
       "dependencies": {
         "cliui": {
           "version": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "dev": true,
-          "requires": {
-            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "wrap-ansi": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz"
-          }
+          "dev": true
         },
         "window-size": {
           "version": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
@@ -15289,60 +13393,25 @@
         "yargs": {
           "version": "https://registry.npmjs.org/yargs/-/yargs-5.0.0.tgz",
           "integrity": "sha1-M1UUSXfQV1fbuG1uOOwFYSOzpm4=",
-          "dev": true,
-          "requires": {
-            "cliui": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-            "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-            "get-caller-file": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-            "lodash.assign": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-            "os-locale": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-            "read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-            "require-directory": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-            "require-main-filename": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-            "set-blocking": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-            "which-module": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-            "window-size": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-            "y18n": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-            "yargs-parser": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-3.2.0.tgz"
-          }
+          "dev": true
         }
       }
     },
     "jest-snapshot": {
       "version": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-16.0.2.tgz",
       "integrity": "sha1-8TekF21mG9QFiRCFAZHRgWvr2q4=",
-      "dev": true,
-      "requires": {
-        "jest-diff": "https://registry.npmjs.org/jest-diff/-/jest-diff-16.0.0.tgz",
-        "jest-file-exists": "https://registry.npmjs.org/jest-file-exists/-/jest-file-exists-15.0.0.tgz",
-        "jest-matcher-utils": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-16.0.0.tgz",
-        "jest-util": "https://registry.npmjs.org/jest-util/-/jest-util-16.0.2.tgz",
-        "natural-compare": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-        "pretty-format": "https://registry.npmjs.org/pretty-format/-/pretty-format-4.2.3.tgz"
-      }
+      "dev": true
     },
     "jest-util": {
       "version": "https://registry.npmjs.org/jest-util/-/jest-util-16.0.2.tgz",
       "integrity": "sha1-21EjNYJ456NKbZ+DdAnWSaDbXVQ=",
-      "dev": true,
-      "requires": {
-        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-        "diff": "https://registry.npmjs.org/diff/-/diff-3.1.0.tgz",
-        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-        "jest-file-exists": "https://registry.npmjs.org/jest-file-exists/-/jest-file-exists-15.0.0.tgz",
-        "jest-mock": "https://registry.npmjs.org/jest-mock/-/jest-mock-16.0.2.tgz",
-        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
-      }
+      "dev": true
     },
     "jodid25519": {
       "version": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
       "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
       "dev": true,
-      "optional": true,
-      "requires": {
-        "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
-      }
+      "optional": true
     },
     "js-base64": {
       "version": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
@@ -15356,11 +13425,7 @@
     "js-yaml": {
       "version": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
       "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
-      "dev": true,
-      "requires": {
-        "argparse": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-        "esprima": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
-      }
+      "dev": true
     },
     "jsbn": {
       "version": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
@@ -15372,28 +13437,6 @@
       "version": "https://registry.npmjs.org/jsdom/-/jsdom-9.8.3.tgz",
       "integrity": "sha1-/eKcEJwyoRMeC2xlkU5kGY+Xw3A=",
       "dev": true,
-      "requires": {
-        "abab": "https://registry.npmjs.org/abab/-/abab-1.0.3.tgz",
-        "acorn": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
-        "acorn-globals": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
-        "array-equal": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-        "content-type-parser": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.1.tgz",
-        "cssom": "https://registry.npmjs.org/cssom/-/cssom-0.3.1.tgz",
-        "cssstyle": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
-        "escodegen": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
-        "html-encoding-sniffer": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz",
-        "iconv-lite": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz",
-        "nwmatcher": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.3.9.tgz",
-        "parse5": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
-        "request": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-        "sax": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-        "symbol-tree": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.1.4.tgz",
-        "tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-        "webidl-conversions": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-        "whatwg-encoding": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.1.tgz",
-        "whatwg-url": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-3.1.0.tgz",
-        "xml-name-validator": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz"
-      },
       "dependencies": {
         "acorn": {
           "version": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
@@ -15420,10 +13463,7 @@
     "json-stable-stringify": {
       "version": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true,
-      "requires": {
-        "jsonify": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
-      }
+      "dev": true
     },
     "json-stringify-safe": {
       "version": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -15443,10 +13483,7 @@
     "jsonfile": {
       "version": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
-      }
+      "dev": true
     },
     "jsonify": {
       "version": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
@@ -15461,37 +13498,22 @@
     "jsprim": {
       "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
       "integrity": "sha1-KnJW9wQSop7jZwqspiWZTE3P8lI=",
-      "dev": true,
-      "requires": {
-        "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-        "json-schema": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-        "verror": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
-      }
+      "dev": true
     },
     "jsx-ast-utils": {
       "version": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.3.4.tgz",
       "integrity": "sha1-AlftHMSx5ls519mUD5+08g97oKk=",
-      "dev": true,
-      "requires": {
-        "acorn-jsx": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
-      }
+      "dev": true
     },
     "kind-of": {
       "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
       "integrity": "sha1-e47PGKThf4Jp1ztQHJ8jLJaIenQ=",
-      "dev": true,
-      "requires": {
-        "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz"
-      }
+      "dev": true
     },
     "klaw": {
       "version": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
-      }
+      "dev": true
     },
     "lazy-cache": {
       "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
@@ -15501,42 +13523,22 @@
     "lcid": {
       "version": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "dev": true,
-      "requires": {
-        "invert-kv": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
-      }
+      "dev": true
     },
     "levn": {
       "version": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-        "type-check": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
-      }
+      "dev": true
     },
     "load-json-file": {
       "version": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-        "parse-json": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-        "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-        "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
-      }
+      "dev": true
     },
     "loader-utils": {
       "version": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.16.tgz",
       "integrity": "sha1-8IYyBm7YKCg13/iN+1JwR2Wt7m0=",
       "dev": true,
-      "requires": {
-        "big.js": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
-        "emojis-list": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-        "json5": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
-      },
       "dependencies": {
         "json5": {
           "version": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
@@ -15563,24 +13565,12 @@
     "lodash._baseassign": {
       "version": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "dev": true,
-      "requires": {
-        "lodash._basecopy": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-        "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
-      }
+      "dev": true
     },
     "lodash._baseclone": {
       "version": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
       "integrity": "sha1-MDUZv2OT/n5C802LYw73eU41Qrc=",
-      "dev": true,
-      "requires": {
-        "lodash._arraycopy": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
-        "lodash._arrayeach": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
-        "lodash._baseassign": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-        "lodash._basefor": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
-        "lodash.isarray": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-        "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
-      }
+      "dev": true
     },
     "lodash._basecopy": {
       "version": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
@@ -15600,11 +13590,7 @@
     "lodash._createcompounder": {
       "version": "https://registry.npmjs.org/lodash._createcompounder/-/lodash._createcompounder-3.0.0.tgz",
       "integrity": "sha1-XdLLVTctbnDg4jkvsjBNZjEJEHU=",
-      "dev": true,
-      "requires": {
-        "lodash.deburr": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-3.2.0.tgz",
-        "lodash.words": "https://registry.npmjs.org/lodash.words/-/lodash.words-3.2.0.tgz"
-      }
+      "dev": true
     },
     "lodash._getnative": {
       "version": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
@@ -15624,19 +13610,12 @@
     "lodash.camelcase": {
       "version": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-3.0.1.tgz",
       "integrity": "sha1-kyyLh/ikN3iXxnGXUzKC+Xrqwpg=",
-      "dev": true,
-      "requires": {
-        "lodash._createcompounder": "https://registry.npmjs.org/lodash._createcompounder/-/lodash._createcompounder-3.0.0.tgz"
-      }
+      "dev": true
     },
     "lodash.clonedeep": {
       "version": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
       "integrity": "sha1-oKHkDYKl6on/WxR7hETtY9koJ9s=",
-      "dev": true,
-      "requires": {
-        "lodash._baseclone": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
-        "lodash._bindcallback": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
-      }
+      "dev": true
     },
     "lodash.cond": {
       "version": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
@@ -15650,10 +13629,7 @@
     "lodash.deburr": {
       "version": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-3.2.0.tgz",
       "integrity": "sha1-baj1QzSjZqfPTEx2742Aqhs2XtU=",
-      "dev": true,
-      "requires": {
-        "lodash._root": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
-      }
+      "dev": true
     },
     "lodash.indexof": {
       "version": "https://registry.npmjs.org/lodash.indexof/-/lodash.indexof-4.0.5.tgz",
@@ -15673,12 +13649,7 @@
     "lodash.keys": {
       "version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "dev": true,
-      "requires": {
-        "lodash._getnative": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-        "lodash.isarguments": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-        "lodash.isarray": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
-      }
+      "dev": true
     },
     "lodash.pickby": {
       "version": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
@@ -15688,10 +13659,7 @@
     "lodash.words": {
       "version": "https://registry.npmjs.org/lodash.words/-/lodash.words-3.2.0.tgz",
       "integrity": "sha1-TiqGSbwIdFsXxpWxo86P7llmI7M=",
-      "dev": true,
-      "requires": {
-        "lodash._root": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
-      }
+      "dev": true
     },
     "longest": {
       "version": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
@@ -15700,10 +13668,7 @@
     },
     "loose-envify": {
       "version": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-      "integrity": "sha1-ayYkjEL21PpLDYVC947fzeNWQqg=",
-      "requires": {
-        "js-tokens": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
-      }
+      "integrity": "sha1-ayYkjEL21PpLDYVC947fzeNWQqg="
     },
     "lower-case": {
       "version": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.3.tgz",
@@ -15713,11 +13678,7 @@
     "lru-cache": {
       "version": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
       "integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4=",
-      "dev": true,
-      "requires": {
-        "pseudomap": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-        "yallist": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz"
-      }
+      "dev": true
     },
     "macaddress": {
       "version": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz",
@@ -15727,10 +13688,7 @@
     "makeerror": {
       "version": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
       "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
-      "dev": true,
-      "requires": {
-        "tmpl": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz"
-      }
+      "dev": true
     },
     "marked": {
       "version": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
@@ -15740,22 +13698,12 @@
     "marked-terminal": {
       "version": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-1.7.0.tgz",
       "integrity": "sha1-yMRgiBx3LHYEtkNnAH7l938SWQQ=",
-      "dev": true,
-      "requires": {
-        "cardinal": "https://registry.npmjs.org/cardinal/-/cardinal-1.0.0.tgz",
-        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-        "cli-table": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
-        "lodash.assign": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-        "node-emoji": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.4.1.tgz"
-      }
+      "dev": true
     },
     "math-expression-evaluator": {
       "version": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.14.tgz",
       "integrity": "sha1-OVEXce2WAkBfupr//xfrTSo4Q6s=",
-      "dev": true,
-      "requires": {
-        "lodash.indexof": "https://registry.npmjs.org/lodash.indexof/-/lodash.indexof-4.0.5.tgz"
-      }
+      "dev": true
     },
     "media-typer": {
       "version": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -15765,11 +13713,7 @@
     "memory-fs": {
       "version": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
       "integrity": "sha1-e8xrYp46Q+hx1+Kaymrop/FcuyA=",
-      "dev": true,
-      "requires": {
-        "errno": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
-        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
-      }
+      "dev": true
     },
     "merge": {
       "version": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
@@ -15789,22 +13733,7 @@
     "micromatch": {
       "version": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-      "dev": true,
-      "requires": {
-        "arr-diff": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-        "array-unique": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-        "braces": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-        "expand-brackets": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-        "extglob": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-        "filename-regex": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
-        "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-        "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
-        "normalize-path": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
-        "object.omit": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-        "parse-glob": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-        "regex-cache": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz"
-      }
+      "dev": true
     },
     "mime": {
       "version": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
@@ -15819,18 +13748,12 @@
     "mime-types": {
       "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
       "integrity": "sha1-4HqqnGxrmnyjASxpADrSWjnpKog=",
-      "dev": true,
-      "requires": {
-        "mime-db": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz"
-      }
+      "dev": true
     },
     "minimatch": {
       "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
       "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
-      "dev": true,
-      "requires": {
-        "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
-      }
+      "dev": true
     },
     "minimist": {
       "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
@@ -15840,10 +13763,7 @@
     "mkdirp": {
       "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
-      "requires": {
-        "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-      }
+      "dev": true
     },
     "ms": {
       "version": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
@@ -15853,13 +13773,7 @@
     "multimatch": {
       "version": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
       "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
-      "dev": true,
-      "requires": {
-        "array-differ": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-        "array-union": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-        "arrify": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
-      }
+      "dev": true
     },
     "mute-stream": {
       "version": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
@@ -15869,7 +13783,6 @@
     "nan": {
       "version": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz",
       "integrity": "sha1-+zxZ1F/k7/4hXwuJD4rfbrMtIjI=",
-      "dev": true,
       "optional": true
     },
     "natural-compare": {
@@ -15880,10 +13793,7 @@
     "ncname": {
       "version": "https://registry.npmjs.org/ncname/-/ncname-1.0.0.tgz",
       "integrity": "sha1-W1etGLHKCShk72Kwse2BlPODtxw=",
-      "dev": true,
-      "requires": {
-        "xml-char-classes": "https://registry.npmjs.org/xml-char-classes/-/xml-char-classes-1.0.0.tgz"
-      }
+      "dev": true
     },
     "negotiator": {
       "version": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
@@ -15893,26 +13803,16 @@
     "no-case": {
       "version": "https://registry.npmjs.org/no-case/-/no-case-2.3.0.tgz",
       "integrity": "sha1-yiglzLdrGOb3nVc9z78erOM90WQ=",
-      "dev": true,
-      "requires": {
-        "lower-case": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.3.tgz"
-      }
+      "dev": true
     },
     "node-emoji": {
       "version": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.4.1.tgz",
       "integrity": "sha1-yfoM+RCUM1vLlnpvQrIwXBWvLrw=",
-      "dev": true,
-      "requires": {
-        "string.prototype.codepointat": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.0.tgz"
-      }
+      "dev": true
     },
     "node-fetch": {
       "version": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
-      "integrity": "sha1-3CNO3WSJmC1Y6PDbT2lQKavNjAQ=",
-      "requires": {
-        "encoding": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-        "is-stream": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
-      }
+      "integrity": "sha1-3CNO3WSJmC1Y6PDbT2lQKavNjAQ="
     },
     "node-int64": {
       "version": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -15923,31 +13823,6 @@
       "version": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.6.0.tgz",
       "integrity": "sha1-JEgG1E0xngSLyGB7XMTq+aKdLjw=",
       "dev": true,
-      "requires": {
-        "assert": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
-        "browserify-zlib": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
-        "buffer": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-        "console-browserify": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
-        "constants-browserify": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
-        "crypto-browserify": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.8.tgz",
-        "domain-browser": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
-        "events": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-        "http-browserify": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
-        "https-browserify": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz",
-        "os-browserify": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
-        "path-browserify": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
-        "process": "https://registry.npmjs.org/process/-/process-0.11.9.tgz",
-        "punycode": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-        "querystring-es3": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
-        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-        "stream-browserify": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
-        "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-        "timers-browserify": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
-        "tty-browserify": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
-        "url": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-        "util": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-        "vm-browserify": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz"
-      },
       "dependencies": {
         "isarray": {
           "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -15957,13 +13832,7 @@
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-          }
+          "dev": true
         }
       }
     },
@@ -15971,15 +13840,6 @@
       "version": "https://registry.npmjs.org/node-notifier/-/node-notifier-4.6.1.tgz",
       "integrity": "sha1-BW0UJE89zBzq3+aK+c/wxUc6M/M=",
       "dev": true,
-      "requires": {
-        "cli-usage": "https://registry.npmjs.org/cli-usage/-/cli-usage-0.1.4.tgz",
-        "growly": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-        "lodash.clonedeep": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
-        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-        "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-        "shellwords": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.0.tgz",
-        "which": "https://registry.npmjs.org/which/-/which-1.2.12.tgz"
-      },
       "dependencies": {
         "minimist": {
           "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -15991,21 +13851,12 @@
     "nopt": {
       "version": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-      "dev": true,
-      "requires": {
-        "abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
-      }
+      "dev": true
     },
     "normalize-package-data": {
       "version": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
       "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
-      "dev": true,
-      "requires": {
-        "hosted-git-info": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
-        "is-builtin-module": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-        "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-        "validate-npm-package-license": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
-      }
+      "dev": true
     },
     "normalize-path": {
       "version": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
@@ -16020,21 +13871,12 @@
     "normalize-url": {
       "version": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.8.0.tgz",
       "integrity": "sha1-qVULB5qjUjyF143yTu8ZWfzjWas=",
-      "dev": true,
-      "requires": {
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-        "prepend-http": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-        "query-string": "https://registry.npmjs.org/query-string/-/query-string-4.2.3.tgz",
-        "sort-keys": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz"
-      }
+      "dev": true
     },
     "nth-check": {
       "version": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
       "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
-      "dev": true,
-      "requires": {
-        "boolbase": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz"
-      }
+      "dev": true
     },
     "num2fraction": {
       "version": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
@@ -16073,30 +13915,17 @@
     "object.entries": {
       "version": "https://registry.npmjs.org/object.entries/-/object.entries-1.0.3.tgz",
       "integrity": "sha1-9CzHU2Ok+apwN7z7O6s75P/HgCc=",
-      "dev": true,
-      "requires": {
-        "define-properties": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-        "es-abstract": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.6.1.tgz",
-        "function-bind": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
-        "has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz"
-      }
+      "dev": true
     },
     "object.omit": {
       "version": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-      "dev": true,
-      "requires": {
-        "for-own": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
-        "is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
-      }
+      "dev": true
     },
     "on-finished": {
       "version": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-      "dev": true,
-      "requires": {
-        "ee-first": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
-      }
+      "dev": true
     },
     "on-headers": {
       "version": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
@@ -16106,10 +13935,7 @@
     "once": {
       "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
-      "requires": {
-        "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-      }
+      "dev": true
     },
     "onetime": {
       "version": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
@@ -16124,20 +13950,12 @@
     "opn": {
       "version": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
       "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
-      "dev": true,
-      "requires": {
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
-      }
+      "dev": true
     },
     "optimist": {
       "version": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
-      "requires": {
-        "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-        "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-      },
       "dependencies": {
         "wordwrap": {
           "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
@@ -16149,32 +13967,17 @@
     "optionator": {
       "version": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "dev": true,
-      "requires": {
-        "deep-is": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-        "fast-levenshtein": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.5.tgz",
-        "levn": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-        "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-        "type-check": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-        "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
-      }
+      "dev": true
     },
     "original": {
       "version": "https://registry.npmjs.org/original/-/original-1.0.0.tgz",
       "integrity": "sha1-kUf5P6FpbQS+YeAb1QuurKZWvTs=",
       "dev": true,
-      "requires": {
-        "url-parse": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz"
-      },
       "dependencies": {
         "url-parse": {
           "version": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz",
           "integrity": "sha1-CFSGBCKv3P7+tsllxmLUgAFpkns=",
-          "dev": true,
-          "requires": {
-            "querystringify": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz",
-            "requires-port": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
-          }
+          "dev": true
         }
       }
     },
@@ -16191,10 +13994,7 @@
     "os-locale": {
       "version": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-      "dev": true,
-      "requires": {
-        "lcid": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz"
-      }
+      "dev": true
     },
     "os-tmpdir": {
       "version": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -16209,29 +14009,17 @@
     "param-case": {
       "version": "https://registry.npmjs.org/param-case/-/param-case-2.1.0.tgz",
       "integrity": "sha1-Jhn5D9bIKe0LlY8chO0Dp0Wm1wo=",
-      "dev": true,
-      "requires": {
-        "no-case": "https://registry.npmjs.org/no-case/-/no-case-2.3.0.tgz"
-      }
+      "dev": true
     },
     "parse-glob": {
       "version": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "dev": true,
-      "requires": {
-        "glob-base": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-        "is-dotfile": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
-        "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-        "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
-      }
+      "dev": true
     },
     "parse-json": {
       "version": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "dev": true,
-      "requires": {
-        "error-ex": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz"
-      }
+      "dev": true
     },
     "parse5": {
       "version": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
@@ -16251,10 +14039,7 @@
     "path-exists": {
       "version": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-      "dev": true,
-      "requires": {
-        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
-      }
+      "dev": true
     },
     "path-is-absolute": {
       "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -16279,12 +14064,7 @@
     "path-type": {
       "version": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-        "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
-      }
+      "dev": true
     },
     "pbkdf2-compat": {
       "version": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz",
@@ -16304,26 +14084,17 @@
     "pinkie-promise": {
       "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true,
-      "requires": {
-        "pinkie": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-      }
+      "dev": true
     },
     "pkg-dir": {
       "version": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
       "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
-      "dev": true,
-      "requires": {
-        "find-up": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz"
-      }
+      "dev": true
     },
     "pkg-up": {
       "version": "https://registry.npmjs.org/pkg-up/-/pkg-up-1.0.0.tgz",
       "integrity": "sha1-Pgj7RhUlxEIWJKM7n35tCvWwWiY=",
-      "dev": true,
-      "requires": {
-        "find-up": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz"
-      }
+      "dev": true
     },
     "pluralize": {
       "version": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
@@ -16333,159 +14104,87 @@
     "postcss": {
       "version": "https://registry.npmjs.org/postcss/-/postcss-5.2.6.tgz",
       "integrity": "sha1-olLNZ81SWFA18X6a0Ss1E3p73Z4=",
-      "dev": true,
-      "requires": {
-        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-        "js-base64": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
-        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-        "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
-      }
+      "dev": true
     },
     "postcss-calc": {
       "version": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
       "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
-      "dev": true,
-      "requires": {
-        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.6.tgz",
-        "postcss-message-helpers": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
-        "reduce-css-calc": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz"
-      }
+      "dev": true
     },
     "postcss-colormin": {
       "version": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.1.tgz",
       "integrity": "sha1-3FQhtq5vd572v9RzUrlKvlnQMWs=",
-      "dev": true,
-      "requires": {
-        "colormin": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
-        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.6.tgz",
-        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
-      }
+      "dev": true
     },
     "postcss-convert-values": {
       "version": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.5.0.tgz",
       "integrity": "sha1-VwrOsEswYfsl9vRr0DKeerYmPAs=",
-      "dev": true,
-      "requires": {
-        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.6.tgz",
-        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
-      }
+      "dev": true
     },
     "postcss-discard-comments": {
       "version": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
       "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
-      "dev": true,
-      "requires": {
-        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.6.tgz"
-      }
+      "dev": true
     },
     "postcss-discard-duplicates": {
       "version": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.0.2.tgz",
       "integrity": "sha1-Ar5SDpFXH/sQc4dmqYHVdwmJuzI=",
-      "dev": true,
-      "requires": {
-        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.6.tgz"
-      }
+      "dev": true
     },
     "postcss-discard-empty": {
       "version": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
       "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
-      "dev": true,
-      "requires": {
-        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.6.tgz"
-      }
+      "dev": true
     },
     "postcss-discard-overridden": {
       "version": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
       "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
-      "dev": true,
-      "requires": {
-        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.6.tgz"
-      }
+      "dev": true
     },
     "postcss-discard-unused": {
       "version": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
       "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
-      "dev": true,
-      "requires": {
-        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.6.tgz",
-        "uniqs": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
-      }
+      "dev": true
     },
     "postcss-filter-plugins": {
       "version": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
       "integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
-      "dev": true,
-      "requires": {
-        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.6.tgz",
-        "uniqid": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.0.tgz"
-      }
+      "dev": true
     },
     "postcss-load-config": {
       "version": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-1.0.0.tgz",
       "integrity": "sha1-E5n2Dc1r2cMSSy6yKWD3f53Aiz0=",
-      "dev": true,
-      "requires": {
-        "cosmiconfig": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.1.0.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-        "postcss-load-options": "https://registry.npmjs.org/postcss-load-options/-/postcss-load-options-1.0.2.tgz",
-        "postcss-load-plugins": "https://registry.npmjs.org/postcss-load-plugins/-/postcss-load-plugins-2.0.0.tgz"
-      }
+      "dev": true
     },
     "postcss-load-options": {
       "version": "https://registry.npmjs.org/postcss-load-options/-/postcss-load-options-1.0.2.tgz",
       "integrity": "sha1-uZ61dZpYj0st2LZHHGmF9yBg57A=",
-      "dev": true,
-      "requires": {
-        "cosmiconfig": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.1.0.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
-      }
+      "dev": true
     },
     "postcss-load-plugins": {
       "version": "https://registry.npmjs.org/postcss-load-plugins/-/postcss-load-plugins-2.0.0.tgz",
       "integrity": "sha1-KEDY3x0cV+vLHUG19g1FeWUEtD8=",
-      "dev": true,
-      "requires": {
-        "cosmiconfig": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.1.0.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
-      }
+      "dev": true
     },
     "postcss-loader": {
       "version": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-1.0.0.tgz",
       "integrity": "sha1-47ZdDIWWwWWPedfbLSkTEHSNXSo=",
-      "dev": true,
-      "requires": {
-        "loader-utils": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.16.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.6.tgz",
-        "postcss-load-config": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-1.0.0.tgz"
-      }
+      "dev": true
     },
     "postcss-merge-idents": {
       "version": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
       "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
-      "dev": true,
-      "requires": {
-        "has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
-        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.6.tgz",
-        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
-      }
+      "dev": true
     },
     "postcss-merge-longhand": {
       "version": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.1.tgz",
       "integrity": "sha1-/1m13sbVhs4s6hgxOPVcWHb6nNw=",
-      "dev": true,
-      "requires": {
-        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.6.tgz"
-      }
+      "dev": true
     },
     "postcss-merge-rules": {
       "version": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.0.10.tgz",
       "integrity": "sha1-VLNgvoBOfmmlxyImNSR7kqNWnps=",
-      "dev": true,
-      "requires": {
-        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.6.tgz",
-        "vendors": "https://registry.npmjs.org/vendors/-/vendors-1.0.1.tgz"
-      }
+      "dev": true
     },
     "postcss-message-helpers": {
       "version": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
@@ -16495,164 +14194,87 @@
     "postcss-minify-font-values": {
       "version": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
       "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
-      "dev": true,
-      "requires": {
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.6.tgz",
-        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
-      }
+      "dev": true
     },
     "postcss-minify-gradients": {
       "version": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
       "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
-      "dev": true,
-      "requires": {
-        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.6.tgz",
-        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
-      }
+      "dev": true
     },
     "postcss-minify-params": {
       "version": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.0.5.tgz",
       "integrity": "sha1-gtYCZDuGFqYfs2NNft4CiYNtZ/k=",
-      "dev": true,
-      "requires": {
-        "alphanum-sort": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
-        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.6.tgz",
-        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
-        "uniqs": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
-      }
+      "dev": true
     },
     "postcss-minify-selectors": {
       "version": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.0.7.tgz",
       "integrity": "sha1-v7kkj+FNszdw8DZXLea0iXxI2Bw=",
-      "dev": true,
-      "requires": {
-        "alphanum-sort": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
-        "has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
-        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.6.tgz",
-        "postcss-selector-parser": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.2.tgz"
-      }
+      "dev": true
     },
     "postcss-modules-extract-imports": {
       "version": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.0.1.tgz",
       "integrity": "sha1-j7P++abdBCDT9tQ1PPH/c/Kyo0E=",
-      "dev": true,
-      "requires": {
-        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.6.tgz"
-      }
+      "dev": true
     },
     "postcss-modules-local-by-default": {
       "version": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.1.1.tgz",
       "integrity": "sha1-KaEGc/o30ZJRJlyiujFQ2QQOtM4=",
-      "dev": true,
-      "requires": {
-        "css-selector-tokenizer": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.6.0.tgz",
-        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.6.tgz"
-      }
+      "dev": true
     },
     "postcss-modules-scope": {
       "version": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.0.2.tgz",
       "integrity": "sha1-/5dzleXgYgLXNiKQuIsejNBJ3ik=",
-      "dev": true,
-      "requires": {
-        "css-selector-tokenizer": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.6.0.tgz",
-        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.6.tgz"
-      }
+      "dev": true
     },
     "postcss-modules-values": {
       "version": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.2.2.tgz",
       "integrity": "sha1-8OfUdv4e2IxeTH+XUzo+dyrZTKE=",
-      "dev": true,
-      "requires": {
-        "icss-replace-symbols": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.0.2.tgz",
-        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.6.tgz"
-      }
+      "dev": true
     },
     "postcss-normalize-charset": {
       "version": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
       "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
-      "dev": true,
-      "requires": {
-        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.6.tgz"
-      }
+      "dev": true
     },
     "postcss-normalize-url": {
       "version": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.7.tgz",
       "integrity": "sha1-a9kNCkvFod8iwm6mXFMlfcOCn04=",
-      "dev": true,
-      "requires": {
-        "is-absolute-url": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.0.0.tgz",
-        "normalize-url": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.8.0.tgz",
-        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.6.tgz",
-        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
-      }
+      "dev": true
     },
     "postcss-ordered-values": {
       "version": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.2.tgz",
       "integrity": "sha1-votRF0H6strI5hSiMC6dECZ7B3E=",
-      "dev": true,
-      "requires": {
-        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.6.tgz",
-        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
-      }
+      "dev": true
     },
     "postcss-reduce-idents": {
       "version": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.3.1.tgz",
       "integrity": "sha1-Ak6OIZ9SdzMTQIVz25ZFumLS0v4=",
-      "dev": true,
-      "requires": {
-        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.6.tgz",
-        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
-      }
+      "dev": true
     },
     "postcss-reduce-initial": {
       "version": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.0.tgz",
       "integrity": "sha1-j3Obk4KJ7y5Ik21xAXg+R0HKm7s=",
-      "dev": true,
-      "requires": {
-        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.6.tgz"
-      }
+      "dev": true
     },
     "postcss-reduce-transforms": {
       "version": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
       "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
-      "dev": true,
-      "requires": {
-        "has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
-        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.6.tgz",
-        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
-      }
+      "dev": true
     },
     "postcss-selector-parser": {
       "version": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.2.tgz",
       "integrity": "sha1-PXD1rdoTDaUcfAwvwCP1axN0/gg=",
-      "dev": true,
-      "requires": {
-        "flatten": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
-        "indexes-of": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
-        "uniq": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz"
-      }
+      "dev": true
     },
     "postcss-svgo": {
       "version": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.5.tgz",
       "integrity": "sha1-RvwDY/Abq2o2qauwHCKfzEU2MJQ=",
-      "dev": true,
-      "requires": {
-        "is-svg": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
-        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.6.tgz",
-        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
-        "svgo": "https://registry.npmjs.org/svgo/-/svgo-0.7.1.tgz"
-      }
+      "dev": true
     },
     "postcss-unique-selectors": {
       "version": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
       "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
-      "dev": true,
-      "requires": {
-        "alphanum-sort": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
-        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.6.tgz",
-        "uniqs": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
-      }
+      "dev": true
     },
     "postcss-value-parser": {
       "version": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
@@ -16662,12 +14284,7 @@
     "postcss-zindex": {
       "version": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
       "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
-      "dev": true,
-      "requires": {
-        "has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
-        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.6.tgz",
-        "uniqs": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
-      }
+      "dev": true
     },
     "prelude-ls": {
       "version": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -16687,11 +14304,7 @@
     "pretty-error": {
       "version": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.0.2.tgz",
       "integrity": "sha1-p9sZy7Upyp8K89Oi931cr45d7CM=",
-      "dev": true,
-      "requires": {
-        "renderkid": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.0.tgz",
-        "utila": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz"
-      }
+      "dev": true
     },
     "pretty-format": {
       "version": "https://registry.npmjs.org/pretty-format/-/pretty-format-4.2.3.tgz",
@@ -16720,19 +14333,12 @@
     },
     "promise": {
       "version": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
-      "integrity": "sha1-SJZUxpJha4qlWwck+oCbt9tJxb8=",
-      "requires": {
-        "asap": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz"
-      }
+      "integrity": "sha1-SJZUxpJha4qlWwck+oCbt9tJxb8="
     },
     "proxy-addr": {
       "version": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.2.tgz",
       "integrity": "sha1-tMxfImENlTWCTBI675089zxAujc=",
-      "dev": true,
-      "requires": {
-        "forwarded": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
-        "ipaddr.js": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.1.1.tgz"
-      }
+      "dev": true
     },
     "prr": {
       "version": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
@@ -16762,11 +14368,7 @@
     "query-string": {
       "version": "https://registry.npmjs.org/query-string/-/query-string-4.2.3.tgz",
       "integrity": "sha1-nycnPSB6JajuTHuMdNzUXVVtuCI=",
-      "dev": true,
-      "requires": {
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-        "strict-uri-encode": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz"
-      }
+      "dev": true
     },
     "querystring": {
       "version": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
@@ -16786,11 +14388,7 @@
     "randomatic": {
       "version": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
       "integrity": "sha1-EQ3Kv/OX6dz/fAeJzMCkmt8exbs=",
-      "dev": true,
-      "requires": {
-        "is-number": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz"
-      }
+      "dev": true
     },
     "range-parser": {
       "version": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
@@ -16799,12 +14397,7 @@
     },
     "react": {
       "version": "https://registry.npmjs.org/react/-/react-15.4.1.tgz",
-      "integrity": "sha1-SY6RhgJnejmDzQ/SBt/nADiaDdY=",
-      "requires": {
-        "fbjs": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.6.tgz",
-        "loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
-      }
+      "integrity": "sha1-SY6RhgJnejmDzQ/SBt/nADiaDdY="
     },
     "react-addons-test-utils": {
       "version": "https://registry.npmjs.org/react-addons-test-utils/-/react-addons-test-utils-15.4.1.tgz",
@@ -16813,105 +14406,51 @@
     },
     "react-codemirror": {
       "version": "https://registry.npmjs.org/react-codemirror/-/react-codemirror-0.3.0.tgz",
-      "integrity": "sha1-zWvW70WOweA1z9iz/nswyMeIPGw=",
-      "requires": {
-        "classnames": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
-        "codemirror": "https://registry.npmjs.org/codemirror/-/codemirror-5.21.0.tgz",
-        "lodash.debounce": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz"
-      }
+      "integrity": "sha1-zWvW70WOweA1z9iz/nswyMeIPGw="
     },
     "react-dev-utils": {
       "version": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-0.3.0.tgz",
       "integrity": "sha1-SgUnBip1dXnLMW+iVGga7MoJ0Dg=",
-      "dev": true,
-      "requires": {
-        "ansi-html": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.5.tgz",
-        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-        "html-entities": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.0.tgz",
-        "opn": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
-        "sockjs-client": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.0.3.tgz",
-        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
-      }
+      "dev": true
     },
     "react-dom": {
       "version": "https://registry.npmjs.org/react-dom/-/react-dom-15.4.1.tgz",
-      "integrity": "sha1-1UyRMmGq7bF63CBBDQKdzBihNEo=",
-      "requires": {
-        "fbjs": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.6.tgz",
-        "loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
-      }
+      "integrity": "sha1-1UyRMmGq7bF63CBBDQKdzBihNEo="
     },
     "read-pkg": {
       "version": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-      "dev": true,
-      "requires": {
-        "load-json-file": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-        "normalize-package-data": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-        "path-type": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz"
-      }
+      "dev": true
     },
     "read-pkg-up": {
       "version": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-      "dev": true,
-      "requires": {
-        "find-up": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-        "read-pkg": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz"
-      }
+      "dev": true
     },
     "readable-stream": {
       "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
       "integrity": "sha1-qeb+w8fdqF+LsbO6cChgRVb8gl4=",
-      "dev": true,
-      "requires": {
-        "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-        "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-        "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-        "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-        "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-        "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-      }
+      "dev": true
     },
     "readdirp": {
       "version": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
-        "set-immediate-shim": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
-      }
+      "dev": true
     },
     "readline2": {
       "version": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
-      "dev": true,
-      "requires": {
-        "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-        "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-        "mute-stream": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
-      }
+      "dev": true
     },
     "recursive-readdir": {
       "version": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.1.0.tgz",
       "integrity": "sha1-eLe/15WC09dZa4/xvSn71QIp9qo=",
       "dev": true,
-      "requires": {
-        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz"
-      },
       "dependencies": {
         "minimatch": {
           "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
           "integrity": "sha1-DzmKcwDqRB6cNIyD2Yq4ydv5xAo=",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
-          }
+          "dev": true
         }
       }
     },
@@ -16919,9 +14458,6 @@
       "version": "https://registry.npmjs.org/redeyed/-/redeyed-1.0.1.tgz",
       "integrity": "sha1-6WwZO0DAgWsArshCaY5hGF5VSYo=",
       "dev": true,
-      "requires": {
-        "esprima": "https://registry.npmjs.org/esprima/-/esprima-3.0.0.tgz"
-      },
       "dependencies": {
         "esprima": {
           "version": "https://registry.npmjs.org/esprima/-/esprima-3.0.0.tgz",
@@ -16933,20 +14469,12 @@
     "reduce-css-calc": {
       "version": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
       "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
-      "dev": true,
-      "requires": {
-        "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-        "math-expression-evaluator": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.14.tgz",
-        "reduce-function-call": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.1.tgz"
-      }
+      "dev": true
     },
     "reduce-function-call": {
       "version": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.1.tgz",
       "integrity": "sha1-+gLhJuaVgkJjyrkdOlsP3B3Sepo=",
       "dev": true,
-      "requires": {
-        "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz"
-      },
       "dependencies": {
         "balanced-match": {
           "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz",
@@ -16968,21 +14496,12 @@
     "regex-cache": {
       "version": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
       "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
-      "dev": true,
-      "requires": {
-        "is-equal-shallow": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-        "is-primitive": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
-      }
+      "dev": true
     },
     "regexpu-core": {
       "version": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-      "dev": true,
-      "requires": {
-        "regenerate": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
-        "regjsgen": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-        "regjsparser": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz"
-      }
+      "dev": true
     },
     "regjsgen": {
       "version": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
@@ -16993,9 +14512,6 @@
       "version": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "dev": true,
-      "requires": {
-        "jsesc": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
-      },
       "dependencies": {
         "jsesc": {
           "version": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
@@ -17013,40 +14529,21 @@
       "version": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.0.tgz",
       "integrity": "sha1-GFl1Pnpa2/NUQ6ug1ORXnnir7oU=",
       "dev": true,
-      "requires": {
-        "css-select": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
-        "dom-converter": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.1.4.tgz",
-        "htmlparser2": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.3.0.tgz",
-        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-        "utila": "https://registry.npmjs.org/utila/-/utila-0.3.3.tgz"
-      },
       "dependencies": {
         "domhandler": {
           "version": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
           "integrity": "sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=",
-          "dev": true,
-          "requires": {
-            "domelementtype": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
-          }
+          "dev": true
         },
         "domutils": {
           "version": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz",
           "integrity": "sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=",
-          "dev": true,
-          "requires": {
-            "domelementtype": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
-          }
+          "dev": true
         },
         "htmlparser2": {
           "version": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.3.0.tgz",
           "integrity": "sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=",
-          "dev": true,
-          "requires": {
-            "domelementtype": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-            "domhandler": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
-            "domutils": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz",
-            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
-          }
+          "dev": true
         },
         "isarray": {
           "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -17056,13 +14553,7 @@
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-          }
+          "dev": true
         },
         "utila": {
           "version": "https://registry.npmjs.org/utila/-/utila-0.3.3.tgz",
@@ -17084,37 +14575,12 @@
     "repeating": {
       "version": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "dev": true,
-      "requires": {
-        "is-finite": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz"
-      }
+      "dev": true
     },
     "request": {
       "version": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
       "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
       "dev": true,
-      "requires": {
-        "aws-sign2": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-        "aws4": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz",
-        "caseless": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-        "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-        "extend": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-        "forever-agent": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-        "form-data": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
-        "har-validator": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-        "hawk": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-        "http-signature": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-        "is-typedarray": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-        "isstream": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-        "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
-        "oauth-sign": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-        "qs": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz",
-        "stringstream": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-        "tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-        "tunnel-agent": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-        "uuid": "https://registry.npmjs.org/uuid/-/uuid-3.0.0.tgz"
-      },
       "dependencies": {
         "uuid": {
           "version": "https://registry.npmjs.org/uuid/-/uuid-3.0.0.tgz",
@@ -17141,11 +14607,7 @@
     "require-uncached": {
       "version": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-      "dev": true,
-      "requires": {
-        "caller-path": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-        "resolve-from": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz"
-      }
+      "dev": true
     },
     "requires-port": {
       "version": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -17165,27 +14627,17 @@
     "restore-cursor": {
       "version": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-      "dev": true,
-      "requires": {
-        "exit-hook": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-        "onetime": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
-      }
+      "dev": true
     },
     "right-align": {
       "version": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "dev": true,
-      "requires": {
-        "align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz"
-      }
+      "dev": true
     },
     "rimraf": {
       "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
       "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
-      "dev": true,
-      "requires": {
-        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
-      }
+      "dev": true
     },
     "ripemd160": {
       "version": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz",
@@ -17195,10 +14647,7 @@
     "run-async": {
       "version": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-      "dev": true,
-      "requires": {
-        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
-      }
+      "dev": true
     },
     "rx-lite": {
       "version": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
@@ -17209,14 +14658,6 @@
       "version": "https://registry.npmjs.org/sane/-/sane-1.4.1.tgz",
       "integrity": "sha1-iPdj10BA9fDCVrYWPbOZvxEKxxU=",
       "dev": true,
-      "requires": {
-        "exec-sh": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.0.tgz",
-        "fb-watchman": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-1.9.0.tgz",
-        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-        "walker": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
-        "watch": "https://registry.npmjs.org/watch/-/watch-0.10.0.tgz"
-      },
       "dependencies": {
         "minimist": {
           "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -17239,29 +14680,11 @@
       "version": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
       "integrity": "sha1-qVSYQyU5L1FTKndgdg5FlZjIn3o=",
       "dev": true,
-      "requires": {
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-        "depd": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
-        "destroy": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-        "encodeurl": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
-        "escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-        "etag": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
-        "fresh": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
-        "http-errors": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
-        "mime": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-        "ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-        "on-finished": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-        "range-parser": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-        "statuses": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
-      },
       "dependencies": {
         "debug": {
           "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-          }
+          "dev": true
         },
         "mime": {
           "version": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
@@ -17279,23 +14702,11 @@
       "version": "https://registry.npmjs.org/serve-index/-/serve-index-1.8.0.tgz",
       "integrity": "sha1-fF2WwT+xMRAfk8HFd0+FFqHnjTs=",
       "dev": true,
-      "requires": {
-        "accepts": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
-        "batch": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz",
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-        "escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-        "http-errors": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
-        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
-        "parseurl": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
-      },
       "dependencies": {
         "debug": {
           "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-          }
+          "dev": true
         },
         "ms": {
           "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
@@ -17307,13 +14718,7 @@
     "serve-static": {
       "version": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz",
       "integrity": "sha1-1sznaTUF9zPHWd5Xvvwa92wPCAU=",
-      "dev": true,
-      "requires": {
-        "encodeurl": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
-        "escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-        "parseurl": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
-        "send": "https://registry.npmjs.org/send/-/send-0.14.1.tgz"
-      }
+      "dev": true
     },
     "set-blocking": {
       "version": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -17363,50 +14768,29 @@
     "sntp": {
       "version": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "dev": true,
-      "requires": {
-        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-      }
+      "dev": true
     },
     "sockjs": {
       "version": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.18.tgz",
       "integrity": "sha1-2bKJMWyn33dZXvKZ4HXw+TfrQgc=",
       "dev": true,
-      "requires": {
-        "faye-websocket": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
-        "uuid": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz"
-      },
       "dependencies": {
         "faye-websocket": {
           "version": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
           "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
-          "dev": true,
-          "requires": {
-            "websocket-driver": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz"
-          }
+          "dev": true
         }
       }
     },
     "sockjs-client": {
       "version": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.0.3.tgz",
       "integrity": "sha1-sNgoCZhGDrJWTF151+PXz9ijU60=",
-      "dev": true,
-      "requires": {
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-        "eventsource": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
-        "faye-websocket": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.7.3.tgz",
-        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-        "json3": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-        "url-parse": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.7.tgz"
-      }
+      "dev": true
     },
     "sort-keys": {
       "version": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
-      "dev": true,
-      "requires": {
-        "is-plain-obj": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz"
-      }
+      "dev": true
     },
     "source-list-map": {
       "version": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.6.tgz",
@@ -17421,18 +14805,12 @@
     "source-map-support": {
       "version": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.6.tgz",
       "integrity": "sha1-MlUqpktFg5KoXqs7C17mFScWeus=",
-      "dev": true,
-      "requires": {
-        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
-      }
+      "dev": true
     },
     "spdx-correct": {
       "version": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-      "dev": true,
-      "requires": {
-        "spdx-license-ids": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
-      }
+      "dev": true
     },
     "spdx-expression-parse": {
       "version": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
@@ -17453,17 +14831,6 @@
       "version": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
       "integrity": "sha1-MOGl0ykkSXShr2FREznVla9mOLA=",
       "dev": true,
-      "requires": {
-        "asn1": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-        "bcrypt-pbkdf": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
-        "dashdash": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-        "ecc-jsbn": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-        "getpass": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
-        "jodid25519": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-        "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-        "tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
-      },
       "dependencies": {
         "assert-plus": {
           "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -17481,10 +14848,6 @@
       "version": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
       "integrity": "sha1-v5tKv7QrJ011FHnkTg/yZWtvEZM=",
       "dev": true,
-      "requires": {
-        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
-      },
       "dependencies": {
         "isarray": {
           "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -17494,13 +14857,7 @@
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-          }
+          "dev": true
         }
       }
     },
@@ -17522,12 +14879,7 @@
     "string-width": {
       "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "dev": true,
-      "requires": {
-        "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-        "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
-      }
+      "dev": true
     },
     "string.prototype.codepointat": {
       "version": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.0.tgz",
@@ -17542,18 +14894,12 @@
     "strip-ansi": {
       "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-      }
+      "dev": true
     },
     "strip-bom": {
       "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-      "dev": true,
-      "requires": {
-        "is-utf8": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
-      }
+      "dev": true
     },
     "strip-json-comments": {
       "version": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
@@ -17563,32 +14909,17 @@
     "style-loader": {
       "version": "https://registry.npmjs.org/style-loader/-/style-loader-0.13.1.tgz",
       "integrity": "sha1-RoKA77wEcwI806bNVuM7Wh1/w6k=",
-      "dev": true,
-      "requires": {
-        "loader-utils": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.16.tgz"
-      }
+      "dev": true
     },
     "supports-color": {
       "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
       "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-      "dev": true,
-      "requires": {
-        "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
-      }
+      "dev": true
     },
     "svgo": {
       "version": "https://registry.npmjs.org/svgo/-/svgo-0.7.1.tgz",
       "integrity": "sha1-KHMg/tlyywl+csK7FoX5b+CPgDQ=",
-      "dev": true,
-      "requires": {
-        "coa": "https://registry.npmjs.org/coa/-/coa-1.0.1.tgz",
-        "colors": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-        "csso": "https://registry.npmjs.org/csso/-/csso-2.2.1.tgz",
-        "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
-        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-        "sax": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-        "whet.extend": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz"
-      }
+      "dev": true
     },
     "symbol-tree": {
       "version": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.1.4.tgz",
@@ -17599,14 +14930,6 @@
       "version": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
-      "requires": {
-        "ajv": "https://registry.npmjs.org/ajv/-/ajv-4.9.0.tgz",
-        "ajv-keywords": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.1.1.tgz",
-        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-        "slice-ansi": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-        "string-width": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz"
-      },
       "dependencies": {
         "is-fullwidth-code-point": {
           "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -17616,11 +14939,7 @@
         "string-width": {
           "version": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
           "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
-          }
+          "dev": true
         }
       }
     },
@@ -17632,14 +14951,7 @@
     "test-exclude": {
       "version": "https://registry.npmjs.org/test-exclude/-/test-exclude-2.1.3.tgz",
       "integrity": "sha1-qNiWjh2oMmb5hk8oUsVeIg8GQ0o=",
-      "dev": true,
-      "requires": {
-        "arrify": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-        "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-        "read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-        "require-main-filename": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz"
-      }
+      "dev": true
     },
     "testcheck": {
       "version": "https://registry.npmjs.org/testcheck/-/testcheck-0.1.4.tgz",
@@ -17664,10 +14976,7 @@
     "timers-browserify": {
       "version": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
       "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
-      "dev": true,
-      "requires": {
-        "process": "https://registry.npmjs.org/process/-/process-0.11.9.tgz"
-      }
+      "dev": true
     },
     "tmatch": {
       "version": "https://registry.npmjs.org/tmatch/-/tmatch-2.0.1.tgz",
@@ -17692,10 +15001,7 @@
     "tough-cookie": {
       "version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
       "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-      "dev": true,
-      "requires": {
-        "punycode": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
-      }
+      "dev": true
     },
     "tr46": {
       "version": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -17726,19 +15032,12 @@
     "type-check": {
       "version": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
-      }
+      "dev": true
     },
     "type-is": {
       "version": "https://registry.npmjs.org/type-is/-/type-is-1.6.14.tgz",
       "integrity": "sha1-4hljnBfe0coHiQkt1UoDgmuBfLI=",
-      "dev": true,
-      "requires": {
-        "media-typer": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz"
-      }
+      "dev": true
     },
     "typedarray": {
       "version": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -17753,12 +15052,6 @@
       "version": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.4.tgz",
       "integrity": "sha1-opWg3hK2plDAMcQN6w3ECxRWi9I=",
       "dev": true,
-      "requires": {
-        "async": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-        "uglify-to-browserify": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-        "yargs": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
-      },
       "dependencies": {
         "async": {
           "version": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
@@ -17780,10 +15073,7 @@
     "uniqid": {
       "version": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.0.tgz",
       "integrity": "sha1-M9lnn2UCL0iYigP9JOfcr48Qnso=",
-      "dev": true,
-      "requires": {
-        "macaddress": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz"
-      }
+      "dev": true
     },
     "uniqs": {
       "version": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
@@ -17804,10 +15094,6 @@
       "version": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
       "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
       "dev": true,
-      "requires": {
-        "punycode": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-        "querystring": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
-      },
       "dependencies": {
         "punycode": {
           "version": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
@@ -17819,36 +15105,22 @@
     "url-loader": {
       "version": "https://registry.npmjs.org/url-loader/-/url-loader-0.5.7.tgz",
       "integrity": "sha1-Z+h3l1n4AA2nSZSQZoDJQ6mwkl0=",
-      "dev": true,
-      "requires": {
-        "loader-utils": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.16.tgz",
-        "mime": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
-      }
+      "dev": true
     },
     "url-parse": {
       "version": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.7.tgz",
       "integrity": "sha1-Alz/mZZTpFmrNCMhR9iVFMyH10o=",
-      "dev": true,
-      "requires": {
-        "querystringify": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz",
-        "requires-port": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
-      }
+      "dev": true
     },
     "user-home": {
       "version": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
       "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-      "dev": true,
-      "requires": {
-        "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
-      }
+      "dev": true
     },
     "util": {
       "version": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
       "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
       "dev": true,
-      "requires": {
-        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-      },
       "dependencies": {
         "inherits": {
           "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
@@ -17880,11 +15152,7 @@
     "validate-npm-package-license": {
       "version": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-      "dev": true,
-      "requires": {
-        "spdx-correct": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-        "spdx-expression-parse": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
-      }
+      "dev": true
     },
     "vary": {
       "version": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz",
@@ -17899,26 +15167,17 @@
     "verror": {
       "version": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
       "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-      "dev": true,
-      "requires": {
-        "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
-      }
+      "dev": true
     },
     "vm-browserify": {
       "version": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
       "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
-      "dev": true,
-      "requires": {
-        "indexof": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
-      }
+      "dev": true
     },
     "walker": {
       "version": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
-      "dev": true,
-      "requires": {
-        "makeerror": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz"
-      }
+      "dev": true
     },
     "watch": {
       "version": "https://registry.npmjs.org/watch/-/watch-0.10.0.tgz",
@@ -17929,11 +15188,6 @@
       "version": "https://registry.npmjs.org/watchpack/-/watchpack-0.2.9.tgz",
       "integrity": "sha1-Yuqkq15bo1/fwBgnVibjwPXj+ws=",
       "dev": true,
-      "requires": {
-        "async": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-        "chokidar": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz",
-        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
-      },
       "dependencies": {
         "async": {
           "version": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
@@ -17951,23 +15205,6 @@
       "version": "https://registry.npmjs.org/webpack/-/webpack-1.13.2.tgz",
       "integrity": "sha1-8RqW9FjrdSlwqGq+dGwHBPq6+vM=",
       "dev": true,
-      "requires": {
-        "acorn": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-        "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-        "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-        "enhanced-resolve": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
-        "interpret": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz",
-        "loader-utils": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.16.tgz",
-        "memory-fs": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
-        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-        "node-libs-browser": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.6.0.tgz",
-        "optimist": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-        "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-        "tapable": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz",
-        "uglify-js": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.4.tgz",
-        "watchpack": "https://registry.npmjs.org/watchpack/-/watchpack-0.2.9.tgz",
-        "webpack-core": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.8.tgz"
-      },
       "dependencies": {
         "acorn": {
           "version": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
@@ -17978,12 +15215,6 @@
           "version": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.4.tgz",
           "integrity": "sha1-ZeovswWck5RpLxX+2HwrNsFrmt8=",
           "dev": true,
-          "requires": {
-            "async": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-            "uglify-to-browserify": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-            "yargs": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
-          },
           "dependencies": {
             "async": {
               "version": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
@@ -17998,18 +15229,11 @@
       "version": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.8.tgz",
       "integrity": "sha1-7fkTXeAKajwm3Q8UsgivCqSvjQo=",
       "dev": true,
-      "requires": {
-        "source-list-map": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.6.tgz",
-        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
-      },
       "dependencies": {
         "source-map": {
           "version": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true,
-          "requires": {
-            "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
-          }
+          "dev": true
         }
       }
     },
@@ -18017,12 +15241,6 @@
       "version": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.8.4.tgz",
       "integrity": "sha1-6HZckSKIfOnjq9TMnD6zG2HglI0=",
       "dev": true,
-      "requires": {
-        "memory-fs": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
-        "mime": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-        "range-parser": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
-      },
       "dependencies": {
         "mime": {
           "version": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
@@ -18034,48 +15252,22 @@
     "webpack-dev-server": {
       "version": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.16.2.tgz",
       "integrity": "sha1-i+vCxM4cRaFcct12nZugjbMGp5M=",
-      "dev": true,
-      "requires": {
-        "compression": "https://registry.npmjs.org/compression/-/compression-1.6.2.tgz",
-        "connect-history-api-fallback": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.3.0.tgz",
-        "express": "https://registry.npmjs.org/express/-/express-4.14.0.tgz",
-        "http-proxy-middleware": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.2.tgz",
-        "open": "https://registry.npmjs.org/open/-/open-0.0.5.tgz",
-        "optimist": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-        "serve-index": "https://registry.npmjs.org/serve-index/-/serve-index-1.8.0.tgz",
-        "sockjs": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.18.tgz",
-        "sockjs-client": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.0.3.tgz",
-        "stream-cache": "https://registry.npmjs.org/stream-cache/-/stream-cache-0.0.2.tgz",
-        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-        "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-        "webpack-dev-middleware": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.8.4.tgz"
-      }
+      "dev": true
     },
     "webpack-manifest-plugin": {
       "version": "https://registry.npmjs.org/webpack-manifest-plugin/-/webpack-manifest-plugin-1.1.0.tgz",
       "integrity": "sha1-a2xxiq3oolN5lXhLRr0umDYFfKo=",
-      "dev": true,
-      "requires": {
-        "fs-extra": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
-        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
-      }
+      "dev": true
     },
     "webpack-sources": {
       "version": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.1.3.tgz",
       "integrity": "sha1-Fc4vt50KHacnREunx1e/FkKU8xA=",
-      "dev": true,
-      "requires": {
-        "source-list-map": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.6.tgz",
-        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
-      }
+      "dev": true
     },
     "websocket-driver": {
       "version": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
       "integrity": "sha1-XLJVbOuF9Dc8bYI4qmkchFThOjY=",
-      "dev": true,
-      "requires": {
-        "websocket-extensions": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz"
-      }
+      "dev": true
     },
     "websocket-extensions": {
       "version": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz",
@@ -18086,9 +15278,6 @@
       "version": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.1.tgz",
       "integrity": "sha1-PGxFGhmO567FWx7GHQkgxngBpfQ=",
       "dev": true,
-      "requires": {
-        "iconv-lite": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
-      },
       "dependencies": {
         "iconv-lite": {
           "version": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
@@ -18104,11 +15293,7 @@
     "whatwg-url": {
       "version": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-3.1.0.tgz",
       "integrity": "sha1-e9yuSQ+SGu9kUftnOexrvY6Qe/Y=",
-      "dev": true,
-      "requires": {
-        "tr46": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-        "webidl-conversions": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz"
-      }
+      "dev": true
     },
     "whet.extend": {
       "version": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
@@ -18118,10 +15303,7 @@
     "which": {
       "version": "https://registry.npmjs.org/which/-/which-1.2.12.tgz",
       "integrity": "sha1-3me15FAmnxlJCe8j7OTr5Bb6EZI=",
-      "dev": true,
-      "requires": {
-        "isexe": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
-      }
+      "dev": true
     },
     "which-module": {
       "version": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
@@ -18141,19 +15323,12 @@
     "worker-farm": {
       "version": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.3.1.tgz",
       "integrity": "sha1-QzMRK7SbF6oFC4eJXKayys9A5f8=",
-      "dev": true,
-      "requires": {
-        "errno": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
-        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-      }
+      "dev": true
     },
     "wrap-ansi": {
       "version": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz",
       "integrity": "sha1-fTD4+HP5pbvDpk2ryNF34HGuQm8=",
-      "dev": true,
-      "requires": {
-        "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
-      }
+      "dev": true
     },
     "wrappy": {
       "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -18163,10 +15338,7 @@
     "write": {
       "version": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-      "dev": true,
-      "requires": {
-        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
-      }
+      "dev": true
     },
     "xml-char-classes": {
       "version": "https://registry.npmjs.org/xml-char-classes/-/xml-char-classes-1.0.0.tgz",
@@ -18196,22 +15368,12 @@
     "yargs": {
       "version": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
       "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-      "dev": true,
-      "requires": {
-        "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-        "cliui": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-        "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-        "window-size": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
-      }
+      "dev": true
     },
     "yargs-parser": {
       "version": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-3.2.0.tgz",
       "integrity": "sha1-UIE1XRnZ0MjF2BrakIy05tGGZk8=",
       "dev": true,
-      "requires": {
-        "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-        "lodash.assign": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz"
-      },
       "dependencies": {
         "camelcase": {
           "version": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
   "dependencies": {
     "axios": "^0.16.2",
     "babel-standalone": "^6.19.0",
+    "deep-equal": "^1.0.1",
+    "deep-freeze": "0.0.1",
     "enzyme": "^2.6.0",
     "react": "^15.4.1",
     "react-codemirror": "^0.3.0",

--- a/public/index.html
+++ b/public/index.html
@@ -7,18 +7,16 @@
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
     <link href="https://fonts.googleapis.com/css?family=Montserrat|Raleway|Open+Sans|Muli" rel="stylesheet">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
-    
-    <title>React Test Module</title>
-  </head>
-  <body>
-    <div id="root"></div>
 
+    <title>React Test Module</title>
+    <!-- these resources are for providing global object in the editor, not for use in the project itself -->
     <script src="https://fb.me/react-15.1.0.min.js"></script>
     <script src="https://fb.me/react-dom-15.1.0.min.js"></script>
-    
     <script src="https://cdnjs.cloudflare.com/ajax/libs/redux/3.6.0/redux.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/redux-thunk/2.1.0/redux-thunk.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/react-redux/4.4.6/react-redux.min.js"></script>
-    
+  </head>
+  <body>
+    <div id="root"></div>
   </body>
 </html>

--- a/src/challenge-templates/React_Redux_Challenge_Template.js
+++ b/src/challenge-templates/React_Redux_Challenge_Template.js
@@ -17,7 +17,7 @@ export const challengeText = `<span class = 'default'>Intro: </span>_CHALLENGE_T
 export const challengeInstructions = `<span class = 'default'>Instructions: </span>_ADD_YOUR_INSTRUCTIONS_HERE_`
 
 // ---------------------------- define challenge seed code ----------------------------
-export const seedCode = 
+export const seedCode =
 `// Redux:
 const ADD = 'ADD';
 
@@ -31,7 +31,10 @@ const addMessage = (message) => {
 const reducer = (state = [], action) => {
   switch (action.type) {
     case ADD:
-      return state.concat(action.message);
+      return [
+			  ...state,
+			  action.message
+			];
     default:
       return state;
   }
@@ -87,7 +90,7 @@ const mapStateToProps = (state) => {
 };
 
 const mapDispatchToProps = (dispatch) => {
-  return { 
+  return {
     submitMessage:
     	(newMessage) => {
         dispatch(addMessage(newMessage))
@@ -149,10 +152,10 @@ export const executeTests = (code) => {
 
 	// this applies an export to the user's code so
 	// we can access their component here for tests
-	
+
 	// const exportScript = '\n export default MyComponent'
 	// const modifiedCode = code.concat(exportScript);
-	
+
 	// test 0: try to transpile JSX, ES6 code to ES5 in browser
 	try {
 		es5 = transform(code, { presets: [ 'es2015', 'stage-2', 'react' ] }).code;
@@ -160,7 +163,7 @@ export const executeTests = (code) => {
 		passed = false;
 		testResults[0].status = false;
 	}
-	
+
 	// now we will try to shallow render the component with Enzyme's shallow method
 	// you can also use mount to perform a full render to the DOM environment
 	// to do this you must import mount above; i.e. import { shallow, mount } from enzyme
@@ -188,7 +191,7 @@ export const executeTests = (code) => {
 		testResults[2].status = true;
 	} catch (err) {
 		passed = false;
-		testResults[2].status = false;		
+		testResults[2].status = false;
 	}
 
 	// test 3:
@@ -204,7 +207,7 @@ export const executeTests = (code) => {
 		passed,
 		testResults
 	}
-	
+
 }
 
 // ---------------------------- define live render function ----------------------------

--- a/src/challenges/react-redux/React_Redux_03.js
+++ b/src/challenges/react-redux/React_Redux_03.js
@@ -1,6 +1,7 @@
 /* eslint-disable */
 import assert from 'assert'
 import { transform } from 'babel-standalone'
+import deepFreeze from 'deep-freeze';
 
 // SET TO TRUE WHEN QA IS COMPLETE:
 export const QA = true;
@@ -37,7 +38,10 @@ const addMessage = (message) => {
 const messageReducer = (state = [], action) => {
   switch (action.type) {
     case ADD:
-      return state.concat(action.message);
+      return [
+        ...state,
+        action.message
+      ];
     default:
       return state;
   }
@@ -54,7 +58,7 @@ export const executeTests = (code, errorSuppression) => {
 	const error_2 = 'The action creator addMessage should return an object with type equal to ADD and message equal to the message that is passed in.';
 	const error_3 = 'messageReducer should be a function.';
 	const error_4 = 'The store should exist and have an initial state set to an empty array.';
-	const error_5 = 'Dispatching addMessage against the store should add a new message to the array of messages held in state.';
+	const error_5 = 'Dispatching addMessage against the store should immutably add a new message to the array of messages held in state.';
 	const error_6 = 'The messageReducer should return the current state if called with any other actions.';
 
 	let testResults = [
@@ -186,10 +190,10 @@ export const executeTests = (code, errorSuppression) => {
 
 	// test 5:
 	try {
-
+		const isFrozen = deepFreeze(initialState);
 		store.dispatch(addMessage('__A__TEST__MESSAGE'));
 		addState = store.getState();
-		assert.strictEqual(addState[0], '__A__TEST__MESSAGE', error_5);
+		assert(isFrozen && addState[0] === '__A__TEST__MESSAGE', error_5);
 
 		testResults[5].status = true;
 	} catch (err) {

--- a/src/challenges/react-redux/React_Redux_04.js
+++ b/src/challenges/react-redux/React_Redux_04.js
@@ -44,11 +44,16 @@ const addMessage = (message) => {
 const messageReducer = (state = [], action) => {
   switch (action.type) {
     case ADD:
-      return state.concat(action.message);
+      return [
+        ...state,
+        action.message
+      ];
     default:
       return state;
   }
 };
+
+
 
 const store = Redux.createStore(messageReducer);
 
@@ -118,7 +123,10 @@ const addMessage = (message) => {
 const messageReducer = (state = [], action) => {
   switch (action.type) {
     case ADD:
-      return state.concat(action.message);
+      return [
+        ...state,
+        action.message
+      ];
     default:
       return state;
   }

--- a/src/challenges/react-redux/React_Redux_08.js
+++ b/src/challenges/react-redux/React_Redux_08.js
@@ -34,7 +34,10 @@ const addMessage = (message) => {
 const messageReducer = (state = [], action) => {
   switch (action.type) {
     case ADD:
-      return state.concat(action.message);
+      return [
+        ...state,
+        action.message
+      ];
     default:
       return state;
   }
@@ -130,7 +133,10 @@ const addMessage = (message) => {
 const messageReducer = (state = [], action) => {
   switch (action.type) {
     case ADD:
-      return state.concat(action.message);
+      return [
+        ...state,
+        action.message
+      ];
     default:
       return state;
   }

--- a/src/challenges/react-redux/React_Redux_09.js
+++ b/src/challenges/react-redux/React_Redux_09.js
@@ -34,7 +34,10 @@ const addMessage = (message) => {
 const messageReducer = (state = [], action) => {
   switch (action.type) {
     case ADD:
-      return state.concat(action.message);
+      return [
+        ...state,
+        action.message
+      ];
     default:
       return state;
   }
@@ -127,7 +130,10 @@ const addMessage = (message) => {
 const messageReducer = (state = [], action) => {
   switch (action.type) {
     case ADD:
-      return state.concat(action.message);
+      return [
+        ...state,
+        action.message
+      ];
     default:
       return state;
   }

--- a/src/challenges/redux/Redux_14.js
+++ b/src/challenges/redux/Redux_14.js
@@ -1,5 +1,7 @@
 /* eslint-disable */
 import assert from 'assert'
+import deepEqual from 'deep-equal';
+import deepFreeze from 'deep-freeze';
 import { transform } from 'babel-standalone'
 
 // SET TO TRUE WHEN QA IS COMPLETE:
@@ -35,8 +37,8 @@ const todos = [
 const immutableReducer = (state = todos, action) => {
 	switch(action.type) {
 		case ADD_TO_DO:
-			return // don't mutate state here
-
+			// don't mutate state here or the tests will fail
+			return
 		default:
 			return state;
 	}
@@ -46,7 +48,7 @@ const immutableReducer = (state = todos, action) => {
 const addToDo = (todo) => {
 	return {
 		type: ADD_TO_DO,
-		payload: todo
+		todo
 	}
 }
 
@@ -67,7 +69,7 @@ const todos = [
 const immutableReducer = (state = todos, action) => {
 	switch(action.type) {
 		case ADD_TO_DO:
-			return state.concat(action.payload);
+			return state.concat(action.todo);
 		default:
 			return state;
 	}
@@ -77,7 +79,7 @@ const immutableReducer = (state = todos, action) => {
 const addToDo = (todo) => {
 	return {
 		type: ADD_TO_DO,
-		payload: todo
+		todo
 	}
 }
 
@@ -90,7 +92,7 @@ export const executeTests = (code, errorSuppression) => {
 	const error_0 = 'Your code should transpile successfully.';
 	const error_1 = 'The Redux store should exist and initialize with a state equal to the todos array in the code editor.';
 	const error_2 = 'addToDo and immutableReducer both should be functions.';
-	const error_3 = 'Dispatching an action of type \'ADD_TO_DO\' on the Redux store should add a todo and return a new copy of state.';
+	const error_3 = 'Dispatching an action of type \'ADD_TO_DO\' on the Redux store should add a todo and should NOT mutate state.';
 
 	let testResults = [
 		{
@@ -185,12 +187,19 @@ export const executeTests = (code, errorSuppression) => {
 
 	// test 3:
 	try {
+		const isFrozen = deepFreeze(initialState);
 		store.dispatch(addToDo('__TEST__TO__DO__'));
 		finalState = store.getState();
+		const expectedState = [
+			'Go to the store',
+			'Clean the house',
+			'Cook dinner',
+			'Learn to code',
+			'__TEST__TO__DO__'
+		];
 		assert(
-			finalState.length === initialState.length + 1 &&
-			finalState.join(',') === initialState.concat('__TEST__TO__DO__').join(',') &&
-			finalState.pop() === '__TEST__TO__DO__',
+			isFrozen &&
+			deepEqual(finalState, expectedState),
 			error_3
 		);
 		testResults[3].status = true;

--- a/src/challenges/redux/Redux_15.js
+++ b/src/challenges/redux/Redux_15.js
@@ -1,5 +1,7 @@
 /* eslint-disable */
 import assert from 'assert'
+import deepEqual from 'deep-equal';
+import deepFreeze from 'deep-freeze';
 import { transform } from 'babel-standalone'
 
 // SET TO TRUE WHEN QA IS COMPLETE:
@@ -25,8 +27,8 @@ export const seedCode =
 `const immutableReducer = (state = ['Do not mutate state!'], action) => {
 	switch(action.type) {
 		case 'ADD_TO_DO':
-			return // don't mutate state here
-
+			// don't mutate state here or the tests will fail
+			return
 		default:
 			return state;
 	}
@@ -46,7 +48,10 @@ export const solutionCode =
 `const immutableReducer = (state = ['Do not mutate state!'], action) => {
 	switch(action.type) {
 		case 'ADD_TO_DO':
-			return [...state, action.todo];
+			return [
+				...state,
+				action.todo
+			];
 		default:
 			return state;
 	}
@@ -68,7 +73,7 @@ export const executeTests = (code, errorSuppression) => {
 	const error_0 = 'Your code should transpile successfully.';
 	const error_1 = 'The Redux store should exist and initialize with a state equal to [\'Don\'t mutate state!\']';
 	const error_2 = 'addToDo and immutableReducer both should be functions.';
-	const error_3 = 'Dispatching an action of type \'ADD_TO_DO\' on the Redux store should add a todo and returns a new copy of state.';
+	const error_3 = 'Dispatching an action of type \'ADD_TO_DO\' on the Redux store should add a todo and should NOT mutate state.';
 	const error_4 = 'The spread operator should be used to return new state.';
 
 	let testResults = [
@@ -163,14 +168,16 @@ export const executeTests = (code, errorSuppression) => {
 
 	// test 3:
 	try {
+		const isFrozen = deepFreeze(initialState);
 		store.dispatch(addToDo('__TEST__TO__DO__'));
 		finalState = store.getState();
+		const expectedState = [
+			'Do not mutate state!',
+			'__TEST__TO__DO__'
+		];
 		assert(
-			initialState.length === 1 &&
-			initialState[0] === 'Do not mutate state!' &&
-			finalState.length === 2 &&
-			finalState[0] === 'Do not mutate state!' &&
-			finalState[1] === '__TEST__TO__DO__',
+			isFrozen &&
+			deepEqual(finalState, expectedState),
 			error_3
 		);
 		testResults[3].status = true;

--- a/src/challenges/redux/Redux_17.js
+++ b/src/challenges/redux/Redux_17.js
@@ -1,5 +1,7 @@
 /* eslint-disable */
 import assert from 'assert'
+import deepEqual from 'deep-equal';
+import deepFreeze from 'deep-freeze';
 import { transform } from 'babel-standalone'
 
 // SET TO TRUE WHEN QA IS COMPLETE:
@@ -22,19 +24,18 @@ export const challengeInstructions = `<span class = 'default'>Instructions: </sp
 
 // ---------------------------- define challenge seed code ----------------------------
 export const seedCode =
-`const ONLINE = 'ONLINE';
-
-const defaultState = {
+`const defaultState = {
 	user: 'CamperBot',
   status: 'offline',
   friends: '732,982',
-  community: 'Free Code Camp'
+  community: 'freeCodeCamp'
 };
 
 const immutableReducer = (state = defaultState, action) => {
 	switch(action.type) {
-		case ONLINE:
-			return // don't mutate state here
+		case 'ONLINE':
+			// don't mutate state here or the tests will fail
+			return
 		default:
 			return state;
 	}
@@ -42,7 +43,7 @@ const immutableReducer = (state = defaultState, action) => {
 
 const wakeUp = () => {
 	return {
-		type: ONLINE
+		type: 'ONLINE'
 	}
 };
 
@@ -50,23 +51,19 @@ const store = Redux.createStore(immutableReducer);`
 
 // ---------------------------- define challenge solution code ----------------------------
 export const solutionCode =
-`const ONLINE = 'ONLINE';
-
-const defaultState = {
+`const defaultState = {
 	user: 'CamperBot',
-  status: 'offline',
-  friends: '732,982',
-  community: 'Free Code Camp'
+	status: 'offline',
+	friends: '732,982',
+	community: 'freeCodeCamp'
 };
 
 const immutableReducer = (state = defaultState, action) => {
 	switch(action.type) {
-		case ONLINE:
-			return Object.assign(
-				{},
-				state,
-        {status: 'online'}
-			);
+		case 'ONLINE':
+			return Object.assign({}, state, {
+				status: 'online'
+			});
 		default:
 			return state;
 	}
@@ -74,7 +71,7 @@ const immutableReducer = (state = defaultState, action) => {
 
 const wakeUp = () => {
 	return {
-		type: ONLINE
+		type: 'ONLINE'
 	}
 };
 
@@ -85,9 +82,10 @@ const store = Redux.createStore(immutableReducer);`
 export const executeTests = (code, errorSuppression) => {
 
 	const error_0 = 'Your code should transpile successfully.';
-	const error_1 = 'The Redux store should exist and initialize with a state that\'s an object with keys \'user\', \'status\', \'friends\', and \'community\'';
+	const error_1 = 'The Redux store should exist and initialize with a state that\'s equivalent to the defaultState object declared on line 1.';
 	const error_2 = 'wakeUp and immutableReducer both should be functions.';
-	const error_3 = 'Dispatching an action of type \'ONLINE\' should update the property \'status\' in state to \'online\' and return a new state object.';
+	const error_3 = 'Dispatching an action of type \'ONLINE\' should update the property \'status\' in state to \'online\' and should NOT mutate state.';
+	const error_4 = 'Object.assign should be used to return new state.';
 
 	let testResults = [
 		{
@@ -109,6 +107,11 @@ export const executeTests = (code, errorSuppression) => {
 			test: 3,
 			status: false,
 			condition: error_3
+		},
+		{
+			test: 4,
+			status: false,
+			condition: error_4
 		}
 	];
 
@@ -146,17 +149,20 @@ export const executeTests = (code, errorSuppression) => {
 		if (!errorSuppression) console.error(`Code evaluation error: ${err}`);
 	}
 
-	let initialState, newState;
+	let initialState, finalState;
 
 	// test 1:
 	try {
+		const expectedState = {
+			user: 'CamperBot',
+			status: 'offline',
+			friends: '732,982',
+			community: 'freeCodeCamp'
+		};
 		initialState = store.getState();
-		assert(
-			typeof initialState === 'object' &&
-			initialState.hasOwnProperty('user') &&
-			initialState.hasOwnProperty('status') &&
-			initialState.hasOwnProperty('friends') &&
-			initialState.hasOwnProperty('community'),
+		assert.deepEqual(
+			expectedState,
+			initialState,
 			error_1
 		);
 		testResults[1].status = true;
@@ -180,17 +186,33 @@ export const executeTests = (code, errorSuppression) => {
 
 	// test 3:
 	try {
+		const isFrozen = deepFreeze(initialState);
 		store.dispatch({type: 'ONLINE'});
-		newState = store.getState();
+		finalState = store.getState();
+		const expectedState = {
+			user: 'CamperBot',
+		  status: 'online',
+		  friends: '732,982',
+		  community: 'freeCodeCamp'
+		};
 		assert(
-			initialState.status === 'offline' &&
-			newState.status === 'online',
+			isFrozen &&
+			deepEqual(finalState, expectedState),
 			error_3
 		);
 		testResults[3].status = true;
 	} catch (err) {
 		passed = false;
 		testResults[3].status = false;
+	}
+
+	// test 4:
+	try {
+		assert.strictEqual(code.includes('Object.assign'), true, error_4);
+		testResults[4].status = true;
+	} catch (err) {
+		passed = false;
+		testResults[4].status = false;
 	}
 
 	return {

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,17 @@ import App from './App'
 
 // import all CSS
 import 'codemirror/lib/codemirror.css'
-import 'codemirror/theme/monokai.css' 	
+import 'codemirror/theme/monokai.css'
 import './index.css'
 
 ReactDOM.render(<App />, document.getElementById('root'));
+
+if (module.hot) {
+  module.hot.accept('./App', () => {
+    const NextApp = require('./App').default;
+    ReactDOM.render(
+      <NextApp />,
+      document.getElementById('root')
+    );
+  });
+}

--- a/src/test-components/ReactTestComponent.js
+++ b/src/test-components/ReactTestComponent.js
@@ -2,13 +2,16 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import CodeMirror from 'react-codemirror';
+import 'codemirror/mode/jsx/jsx';
+import 'codemirror/addon/edit/matchbrackets';
+import 'codemirror/addon/edit/closebrackets';
+import 'codemirror/keymap/sublime';
 import {
 	keyboard,
 	editorOptions,
 	challengeProps,
 	renderChallenges,
 } from './shared.js';
-import 'codemirror/mode/jsx/jsx';
 
 export default class ReactTestComponent extends React.Component {
 	static propTypes = challengeProps;

--- a/src/test-components/ReduxTestComponent.js
+++ b/src/test-components/ReduxTestComponent.js
@@ -1,13 +1,16 @@
 /* eslint-disable */
 import React, { PropTypes } from 'react';
 import CodeMirror from 'react-codemirror';
+import 'codemirror/mode/jsx/jsx';
+import 'codemirror/addon/edit/matchbrackets';
+import 'codemirror/addon/edit/closebrackets';
+import 'codemirror/keymap/sublime';
 import {
 	keyboard,
 	editorOptions,
 	challengeProps,
 	renderChallenges,
 } from './shared.js';
-import 'codemirror/mode/jsx/jsx';
 
 export default class ReduxTestComponent extends React.Component {
 	static propTypes = challengeProps;

--- a/src/test-components/shared.js
+++ b/src/test-components/shared.js
@@ -31,20 +31,23 @@ export const renderChallenges = (challenges) => {
 
 // Code Mirror configuration options
 export const editorOptions = {
+	autoCloseBrackets: true,
+	extraKeys: {
+		'Cmd-Enter': () => {
+			this.testCode();
+			return false;
+		},
+		'Ctrl-Enter': () => {
+			this.testCode();
+			return false;
+		}
+	},
+	keymap: 'sublime',
+	lineNumbers: true,
+	matchBrackets: true,
   mode: 'jsx',
-  lineNumbers: true,
+	tabSize: 2,
   theme: 'monokai',
-  tabSize: 2,
-  extraKeys: {
-    'Cmd-Enter': () => {
-      this.testCode();
-      return false;
-    },
-    'Ctrl-Enter': () => {
-      this.testCode();
-      return false;
-    }
-  }
 };
 
 // helper for evaluating keypresses


### PR DESCRIPTION
- make tests more readable with `deepFreeze` and `deepEqual` for enforcing immutability and making comparisons
- modifies challenges 14-18 (no React-Redux challenges)
- also modify editor in both test components to include auto close brackets, match brackets (bracket underlining), and sublime keybindings
- replaces `.concat` with spread to push ES6 (except for one challenge where we're trying to show you can make immutable operations pre-es6)
- other small changes like removed const ONLINE = 'ONLINE' from challenge 17, since all others just use strings without assigning the string to a variable, and other small consistency things.

@bonham000  kind of in a rush, so feel free to comb through this carefully and let me know if you have any questions!