### PR TITLE
migrate to enzyme 3.x.x failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/node": {
+      "version": "8.0.56",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.56.tgz",
+      "integrity": "sha512-JAlQv3hUWbrnruuTiLDf1scd4F/TBT0LgGEe+BBeF3p/Rc3yL6RV57WJN2nK5i+BshEz1sDllwH0Fzbuo7G4QA=="
+    },
     "Base64": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
@@ -1635,26 +1640,26 @@
       }
     },
     "cheerio": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
-      "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
+      "version": "1.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.2.tgz",
+      "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
       "requires": {
         "css-select": "1.2.0",
         "dom-serializer": "0.1.0",
         "entities": "1.1.1",
         "htmlparser2": "3.9.2",
-        "lodash.assignin": "4.2.0",
-        "lodash.bind": "4.2.1",
-        "lodash.defaults": "4.2.0",
-        "lodash.filter": "4.6.0",
-        "lodash.flatten": "4.4.0",
-        "lodash.foreach": "4.5.0",
-        "lodash.map": "4.6.0",
-        "lodash.merge": "4.6.0",
-        "lodash.pick": "4.4.0",
-        "lodash.reduce": "4.6.0",
-        "lodash.reject": "4.6.0",
-        "lodash.some": "4.6.0"
+        "lodash": "4.17.4",
+        "parse5": "3.0.3"
+      },
+      "dependencies": {
+        "parse5": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
+          "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+          "requires": {
+            "@types/node": "8.0.56"
+          }
+        }
       }
     },
     "chokidar": {
@@ -2362,6 +2367,11 @@
       "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
       "dev": true
     },
+    "discontinuous-range": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo="
+    },
     "doctrine": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
@@ -2512,20 +2522,43 @@
       "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
     },
     "enzyme": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-2.6.0.tgz",
-      "integrity": "sha1-FI10KyXiVl9+gIcKDJKuqb4bkOo=",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.2.0.tgz",
+      "integrity": "sha512-l0HcjycivXjB4IXkwuRc1K5z8hzWIVZB2b/Y/H2bao9eFTpBz4ACOwAQf44SgG5Nu3d1jF41LasxDgFWZeeysA==",
       "requires": {
-        "cheerio": "0.22.0",
+        "cheerio": "1.0.0-rc.2",
         "function.prototype.name": "1.0.3",
-        "in-publish": "2.0.0",
+        "has": "1.0.1",
         "is-subset": "0.1.1",
         "lodash": "4.17.4",
         "object-is": "1.0.1",
         "object.assign": "4.0.4",
         "object.entries": "1.0.4",
         "object.values": "1.0.4",
-        "uuid": "2.0.3"
+        "raf": "3.4.0",
+        "rst-selector-parser": "2.2.3"
+      }
+    },
+    "enzyme-adapter-react-15.4": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/enzyme-adapter-react-15.4/-/enzyme-adapter-react-15.4-1.0.5.tgz",
+      "integrity": "sha512-EM1shx5KbjddW4y2z/AvhKCfmhPdMNUdES0L7rHw1zF5cYWXBtfECNu+6bqYMK66Lgoz2iWHBmnYmQ2alIyaSA==",
+      "requires": {
+        "enzyme-adapter-utils": "1.2.0",
+        "lodash": "4.17.4",
+        "object.assign": "4.0.4",
+        "object.values": "1.0.4",
+        "prop-types": "15.6.0"
+      }
+    },
+    "enzyme-adapter-utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.2.0.tgz",
+      "integrity": "sha512-6CeIrmymLWoQgvH5m/ixJLaCsa6pSoWU2nlMeO0nHCZR8LQ+tKzP/jPh4qceTPlB4oFfyMRFeqr0+IryY4gAxg==",
+      "requires": {
+        "lodash": "4.17.4",
+        "object.assign": "4.0.4",
+        "prop-types": "15.6.0"
       }
     },
     "errno": {
@@ -4738,11 +4771,6 @@
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
-    "in-publish": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
-      "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E="
-    },
     "indexes-of": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
@@ -5861,16 +5889,6 @@
       "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
       "dev": true
     },
-    "lodash.assignin": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
-      "integrity": "sha1-uo31+4QesKPoBEIysOJjqNxqKKI="
-    },
-    "lodash.bind": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
-      "integrity": "sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU="
-    },
     "lodash.camelcase": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-3.0.1.tgz",
@@ -5910,25 +5928,10 @@
         "lodash._root": "3.0.1"
       }
     },
-    "lodash.defaults": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
-    },
-    "lodash.filter": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
-      "integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4="
-    },
-    "lodash.flatten": {
+    "lodash.flattendeep": {
       "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
-    },
-    "lodash.foreach": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
-      "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
+      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI="
     },
     "lodash.isarguments": {
       "version": "3.1.0",
@@ -5953,47 +5956,17 @@
         "lodash.isarray": "3.0.4"
       }
     },
-    "lodash.map": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
-      "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM="
-    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
     },
-    "lodash.merge": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
-      "integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU="
-    },
-    "lodash.pick": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
-    },
     "lodash.pickby": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
       "integrity": "sha1-feoh2MGNdwOifHBMFdO4SmfjOv8=",
       "dev": true
-    },
-    "lodash.reduce": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
-      "integrity": "sha1-8atrg5KZrUj3hKu/R2WW8DuRTTs="
-    },
-    "lodash.reject": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz",
-      "integrity": "sha1-gNZJLcFHCGS79YNTO2UfQqn1JBU="
-    },
-    "lodash.some": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
-      "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0="
     },
     "lodash.toarray": {
       "version": "4.4.0",
@@ -6231,6 +6204,16 @@
         "xml-char-classes": "1.0.0"
       }
     },
+    "nearley": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.11.0.tgz",
+      "integrity": "sha512-clqqhEuP0ZCJQ85Xv2I/4o2Gs/fvSR6fCg5ZHVE2c8evWyNk2G++ih4JOO3lMb/k/09x6ihQ2nzKUlB/APCWjg==",
+      "requires": {
+        "nomnom": "1.6.2",
+        "railroad-diagrams": "1.0.0",
+        "randexp": "0.4.6"
+      }
+    },
     "negotiator": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
@@ -6347,6 +6330,22 @@
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
+        }
+      }
+    },
+    "nomnom": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.6.2.tgz",
+      "integrity": "sha1-hKZqJgF0QI/Ft3oY+IjszET7aXE=",
+      "requires": {
+        "colors": "0.5.1",
+        "underscore": "1.4.4"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
+          "integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q="
         }
       }
     },
@@ -6727,8 +6726,7 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pify": {
       "version": "2.3.0",
@@ -7577,6 +7575,28 @@
       "integrity": "sha1-DPf4T5Rj/wrlHExLFC2VvjdyTZw=",
       "dev": true
     },
+    "raf": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.0.tgz",
+      "integrity": "sha512-pDP/NMRAXoTfrhCfyfSEwJAKLaxBU9eApMeBPB1TkDouZmvPerIClV8lTAd+uF8ZiTaVl69e1FCxQrAd/VTjGw==",
+      "requires": {
+        "performance-now": "2.1.0"
+      }
+    },
+    "railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234="
+    },
+    "randexp": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+      "requires": {
+        "discontinuous-range": "1.0.0",
+        "ret": "0.1.15"
+      }
+    },
     "randomatic": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
@@ -8106,6 +8126,11 @@
         "onetime": "1.1.0"
       }
     },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+    },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
@@ -8129,6 +8154,15 @@
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz",
       "integrity": "sha1-K/GYveFnys+lHAqSjoS2i74XH84=",
       "dev": true
+    },
+    "rst-selector-parser": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
+      "integrity": "sha1-gbIw6i/MYGbInjRy3nlChdmwPZE=",
+      "requires": {
+        "lodash.flattendeep": "4.4.0",
+        "nearley": "2.11.0"
+      }
     },
     "run-async": {
       "version": "0.1.0",
@@ -8833,6 +8867,11 @@
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
       "dev": true
     },
+    "underscore": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
+      "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
+    },
     "uniq": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
@@ -8954,11 +8993,6 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
       "dev": true
-    },
-    "uuid": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-      "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
     },
     "validate-npm-package-license": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "babel-standalone": "^6.19.0",
     "deep-equal": "^1.0.1",
     "deep-freeze": "0.0.1",
-    "enzyme": "2.6.0",
+    "enzyme": "^3.2.0",
+    "enzyme-adapter-react-15.4": "^1.0.5",
     "react": "^15.4.1",
     "react-codemirror": "^0.3.0",
     "react-dom": "^15.4.1"

--- a/src/challenges/Enzyme.js
+++ b/src/challenges/Enzyme.js
@@ -1,0 +1,4 @@
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-15.4';
+
+export default Enzyme.configure({ adapter: new Adapter() });

--- a/src/challenges/react-redux/React_Redux_01.js
+++ b/src/challenges/react-redux/React_Redux_01.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { mount } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // ---------------------------- define challenge title ----------------------------

--- a/src/challenges/react-redux/React_Redux_02.js
+++ b/src/challenges/react-redux/React_Redux_02.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { mount } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // ---------------------------- define challenge title ----------------------------

--- a/src/challenges/react-redux/React_Redux_04.js
+++ b/src/challenges/react-redux/React_Redux_04.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { mount } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // ---------------------------- define challenge title ----------------------------

--- a/src/challenges/react-redux/React_Redux_07.js
+++ b/src/challenges/react-redux/React_Redux_07.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { mount } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // ---------------------------- define challenge title ----------------------------

--- a/src/challenges/react-redux/React_Redux_08.js
+++ b/src/challenges/react-redux/React_Redux_08.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { mount } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // ---------------------------- define challenge title ----------------------------
@@ -335,7 +335,7 @@ export const executeTests = (code, errorSuppression) => {
 
   // test 4:
   try {
-    props = PresentationalComponent.node.props;
+    props = PresentationalComponent.props();
     assert.strictEqual(Array.isArray(props.messages), true, error_4);
     testResults[4].status = true;
   } catch (err) {

--- a/src/challenges/react-redux/React_Redux_09.js
+++ b/src/challenges/react-redux/React_Redux_09.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { mount } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // ---------------------------- define challenge title ----------------------------

--- a/src/challenges/react/React_01.js
+++ b/src/challenges/react/React_01.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { shallow } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // -------------- define challenge title and challenge instructions --------------

--- a/src/challenges/react/React_02.js
+++ b/src/challenges/react/React_02.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { shallow } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // -------------- define challenge title and challenge instructions --------------

--- a/src/challenges/react/React_03.js
+++ b/src/challenges/react/React_03.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { shallow } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // -------------- define challenge title and challenge instructions --------------

--- a/src/challenges/react/React_04.js
+++ b/src/challenges/react/React_04.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { shallow } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // -------------- define challenge title and challenge instructions --------------

--- a/src/challenges/react/React_05.js
+++ b/src/challenges/react/React_05.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { shallow } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // -------------- define challenge title and challenge instructions --------------

--- a/src/challenges/react/React_06.js
+++ b/src/challenges/react/React_06.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { shallow } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // ---------------------------- define challenge title ----------------------------

--- a/src/challenges/react/React_07.js
+++ b/src/challenges/react/React_07.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { mount } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // ---------------------------- define challenge title ----------------------------

--- a/src/challenges/react/React_08.js
+++ b/src/challenges/react/React_08.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { shallow } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // -------------- define challenge title and challenge instructions --------------

--- a/src/challenges/react/React_09.js
+++ b/src/challenges/react/React_09.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { shallow, mount } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // -------------- define challenge title and challenge instructions --------------

--- a/src/challenges/react/React_10.js
+++ b/src/challenges/react/React_10.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { render/**/, shallow, mount } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // -------------- define challenge title and challenge instructions --------------

--- a/src/challenges/react/React_11.js
+++ b/src/challenges/react/React_11.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { shallow, mount} from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // ---------------------------- define challenge title ----------------------------

--- a/src/challenges/react/React_12.js
+++ b/src/challenges/react/React_12.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { shallow } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // ---------------------------- define challenge title ----------------------------

--- a/src/challenges/react/React_13.js
+++ b/src/challenges/react/React_13.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { shallow } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // ---------------------------- define challenge title ----------------------------

--- a/src/challenges/react/React_14.js
+++ b/src/challenges/react/React_14.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { shallow, mount } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // ---------------------------- define challenge title ----------------------------

--- a/src/challenges/react/React_15.js
+++ b/src/challenges/react/React_15.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { shallow, mount } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // ---------------------------- define challenge title ----------------------------

--- a/src/challenges/react/React_16.js
+++ b/src/challenges/react/React_16.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { shallow, mount } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // ---------------------------- define challenge title ----------------------------

--- a/src/challenges/react/React_17.js
+++ b/src/challenges/react/React_17.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { mount } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // ---------------------------- define challenge title ----------------------------

--- a/src/challenges/react/React_18.js
+++ b/src/challenges/react/React_18.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { mount } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // ---------------------------- define challenge title ----------------------------

--- a/src/challenges/react/React_19.js
+++ b/src/challenges/react/React_19.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { shallow, mount } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // ---------------------------- define challenge title ----------------------------

--- a/src/challenges/react/React_20.js
+++ b/src/challenges/react/React_20.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { mount } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // ---------------------------- define challenge title ----------------------------

--- a/src/challenges/react/React_21.js
+++ b/src/challenges/react/React_21.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { mount } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // ---------------------------- define challenge title ----------------------------

--- a/src/challenges/react/React_22.js
+++ b/src/challenges/react/React_22.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { mount } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // ---------------------------- define challenge title ----------------------------

--- a/src/challenges/react/React_23.js
+++ b/src/challenges/react/React_23.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { shallow, mount } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // ---------------------------- define challenge title ----------------------------

--- a/src/challenges/react/React_24.js
+++ b/src/challenges/react/React_24.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { mount } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // ---------------------------- define challenge title ----------------------------

--- a/src/challenges/react/React_25.js
+++ b/src/challenges/react/React_25.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { mount } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // ---------------------------- define challenge title ----------------------------

--- a/src/challenges/react/React_26.js
+++ b/src/challenges/react/React_26.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { mount } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // ---------------------------- define challenge title ----------------------------

--- a/src/challenges/react/React_27.js
+++ b/src/challenges/react/React_27.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { mount } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // ---------------------------- define challenge title ----------------------------

--- a/src/challenges/react/React_28.js
+++ b/src/challenges/react/React_28.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { mount } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // ---------------------------- define challenge title ----------------------------

--- a/src/challenges/react/React_29.js
+++ b/src/challenges/react/React_29.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { mount } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // ---------------------------- define challenge title ----------------------------

--- a/src/challenges/react/React_30.js
+++ b/src/challenges/react/React_30.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { mount } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // ---------------------------- define challenge title ----------------------------

--- a/src/challenges/react/React_31.js
+++ b/src/challenges/react/React_31.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { mount } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // ---------------------------- define challenge title ----------------------------

--- a/src/challenges/react/React_32.js
+++ b/src/challenges/react/React_32.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { mount } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // ---------------------------- define challenge title ----------------------------

--- a/src/challenges/react/React_33.js
+++ b/src/challenges/react/React_33.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { mount } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // ---------------------------- define challenge title ----------------------------

--- a/src/challenges/react/React_34.js
+++ b/src/challenges/react/React_34.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { mount } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // ---------------------------- define challenge title ----------------------------

--- a/src/challenges/react/React_35.js
+++ b/src/challenges/react/React_35.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { mount } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // ---------------------------- define challenge title ----------------------------

--- a/src/challenges/react/React_36.js
+++ b/src/challenges/react/React_36.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { mount } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // ---------------------------- define challenge title ----------------------------

--- a/src/challenges/react/React_37.js
+++ b/src/challenges/react/React_37.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { mount } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // ---------------------------- define challenge title ----------------------------

--- a/src/challenges/react/React_38.js
+++ b/src/challenges/react/React_38.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { shallow } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // ---------------------------- define challenge title ----------------------------

--- a/src/challenges/react/React_39.js
+++ b/src/challenges/react/React_39.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { shallow } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // NOTES: For this one (besides re-doing the intro since we will likely have covered most of this already

--- a/src/challenges/react/React_40.js
+++ b/src/challenges/react/React_40.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { shallow, mount } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // ---------------------------- define challenge title ----------------------------

--- a/src/challenges/react/React_41.js
+++ b/src/challenges/react/React_41.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { mount } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // ---------------------------- define challenge title ----------------------------

--- a/src/challenges/react/React_42.js
+++ b/src/challenges/react/React_42.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { mount } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // ---------------------------- define challenge title ----------------------------

--- a/src/challenges/react/React_43.js
+++ b/src/challenges/react/React_43.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { mount } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // ---------------------------- define challenge title ----------------------------

--- a/src/challenges/react/React_44.js
+++ b/src/challenges/react/React_44.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { shallow, mount } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // ---------------------------- define challenge title ----------------------------

--- a/src/challenges/react/React_45.js
+++ b/src/challenges/react/React_45.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { shallow, mount } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 // ---------------------------- define challenge title ----------------------------
 export const challengeTitle = `<span class = 'default'>Challenge: </span>Render Conditionally from Props`

--- a/src/challenges/react/React_46.js
+++ b/src/challenges/react/React_46.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { mount } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // ---------------------------- define challenge title ----------------------------

--- a/src/challenges/react/React_47.js
+++ b/src/challenges/react/React_47.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { shallow, mount } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // ---------------------------- define challenge title ----------------------------

--- a/src/challenges/react/React_48.js
+++ b/src/challenges/react/React_48.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { shallow, mount } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // ---------------------------- define challenge title ----------------------------

--- a/src/challenges/react/React_49.js
+++ b/src/challenges/react/React_49.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { mount } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // ---------------------------- define challenge title ----------------------------

--- a/src/challenges/react/React_50.js
+++ b/src/challenges/react/React_50.js
@@ -4,7 +4,7 @@ import assert from 'assert'
 import { shallow } from 'enzyme'
 import { transform } from 'babel-standalone'
 
-// SET TO TRUE WHEN QA IS COMPLETE:
+import Enzyme from '../Enzyme';
 export const QA = true;
 
 // ---------------------------- define challenge title ----------------------------


### PR DESCRIPTION
install both new enzyme on new branch as well as adapteer

uncomment `Enzyme` important in React_09 to see that adapter solves failing tests that work otherwise

many tests still failing due mostly to accessing `.node` and `.nodes` properties which are unsupported in 3.x.x

DO NOT MERGE